### PR TITLE
106% display names

### DIFF
--- a/src/asset/categories/106.json
+++ b/src/asset/categories/106.json
@@ -85,7 +85,7 @@
             "Tyrant Dream Entry",
             "[2D] FC Dream Entry"
         ],
-        "SoulTyrantEssence": "Soul Tyrant",
+        "SoulTyrantEssenceWithSanctumGrub": "Soul Tyrant w/ Sanctum Grub",
         "TollBenchBasin": "Basin Toll Bench",
         "LostKinEssence": "Lost Kin",
         "FailedChampionEssence": "Failed Champion",
@@ -93,7 +93,7 @@
         "NightmareLantern": "Nightmare Lantern",
         "Vessel1": "[2D] Storerooms Vessel",
         "Grub18": "Grub 18: Greenpath Cornifer",
-        "MaskFragment2": "Enraged Guardian",
+        "OnObtainMaskShard": "Enraged Guardian",
         "Ore2": "Hallownest Crown",
         "Flame1": "KP Grimmkin Flame",
         "VesselFragment4": "[2U] City Vessel Fragment",

--- a/src/asset/categories/106.json
+++ b/src/asset/categories/106.json
@@ -80,7 +80,7 @@
     "names": {
         "TransClaw": "Mantis Claw Exit",
         "CrystalHeart": "[1U] %s",
-        "ElegantKeyShoptimised": "[1U] %s",
+        "ElegantKey": "[1U] %s",
         "EnterAnyDream": [
             "Tyrant Dream Entry",
             "[2D] FC Dream Entry"
@@ -113,9 +113,10 @@
         "WhiteDefenderEssence": "White Defender",
         "SlyShopFinished": "[3D] Last Shopping",
         "GreyMournerSeerAscended": "[2D] Grey Mourner",
-        "ColosseumBronze": "Colo1",
-        "ColosseumSilver": "Colo2",
-        "ColosseumGold": "Colo3",
+        "ColosseumBronzeUnlocked": "Colos Opened",
+        "ColosseumSilverUnlocked": "Colo 1",
+        "ColosseumGoldUnlocked": "Colo 2",
+        "ColosseumGoldExit": "Colo 3",
         "NailUpgrade4": "Pure Nail",
         "Kingsoul": "[2D] White Palace",
         "NightmareKingGrimm": "[3D] %s",


### PR DESCRIPTION
fixed display names for: [1u] elegant key, Tyrant w/ grub, enraged guardian, colos