### PR TITLE
add CarefreeMelody autosplit

### DIFF
--- a/src/asset/hollowknight/categories/every.json
+++ b/src/asset/hollowknight/categories/every.json
@@ -362,6 +362,7 @@
         "Grimmchild2",
         "Grimmchild3",
         "Grimmchild4",
+        "CarefreeMelody",
         "GrubberflysElegy",
         "Grubsong",
         "HeavyBlow",

--- a/src/asset/hollowknight/icons/icons.ts
+++ b/src/asset/hollowknight/icons/icons.ts
@@ -361,6 +361,7 @@ import Grimmchild from "./Charm/Grimmchild.png";
 import Grimmchild2 from "./Charm/Grimmchild2.png";
 import Grimmchild3 from "./Charm/Grimmchild3.png";
 import Grimmchild4 from "./Charm/Grimmchild4.png";
+import CarefreeMelody from "./Charm/CarefreeMelody.png";
 import GrubberflysElegy from "./Charm/GrubberflysElegy.png";
 import Grubsong from "./Charm/Grubsong.png";
 import HeavyBlow from "./Charm/HeavyBlow.png";
@@ -1072,6 +1073,7 @@ export default {
   Grimmchild2,
   Grimmchild3,
   Grimmchild4,
+  CarefreeMelody,
   GrubberflysElegy,
   Grubsong,
   HeavyBlow,

--- a/src/asset/hollowknight/splits.txt
+++ b/src/asset/hollowknight/splits.txt
@@ -741,6 +741,8 @@
         Grimmchild3,
         [Description("Grimmchild Lvl 4 (Charm)"), ToolTip("Splits when upgrading Grimmchild to level 4")]
         Grimmchild4,
+        [Description("Carefree Melody (Charm)"), ToolTip("Splits when obtaining the Carefree Melody charm")]
+        CarefreeMelody,
         [Description("Grubberfly's Elegy (Charm)"), ToolTip("Splits when obtaining the Grubberfly's Elegy charm")]
         GrubberflysElegy,
         [Description("Grubsong (Charm)"), ToolTip("Splits when obtaining the Grubsong charm")]


### PR DESCRIPTION
Conveniently for me, `src/asset/hollowknight/icons/Charm/CarefreeMelody.png` was already here, so I didn't have to add that myself.
![CarefreeMelody.png](https://github.com/slaurent22/hk-split-maker/blob/main/src/asset/hollowknight/icons/Charm/CarefreeMelody.png?raw=true)