### PR TITLE
Change herrah dreamer split method for fury any%

### DIFF
--- a/src/asset/hollowknight/categories/any-fury.json
+++ b/src/asset/hollowknight/categories/any-fury.json
@@ -16,7 +16,7 @@
         "Uumuu",
         "QueensGardensEntry",
         "BeastsDenTrapBench",
-        "Hegemol",
+        "HegemolDreamer",
         "UnchainedHollowKnight"
     ],
     "endTriggeringAutosplit": false,


### PR DESCRIPTION
Turns out that the new timing method does not work with quitouts, and you optimally do a quitout with this route.