### PR TITLE
More who% stuff

### DIFF
--- a/src/asset/hollowknight/categories/category-directory.json
+++ b/src/asset/hollowknight/categories/category-directory.json
@@ -955,12 +955,26 @@
             "displayName": "Who% (All Glitches)"
         },
         {
+            "fileName": "who-nmms-1028",
+            "displayName": "Who% (No Main Menu Storage, 1028)"
+        },
+        {
+            "fileName": "who-nmms-itemless",
+            "displayName": "Who% (No Main Menu Storage, itemless stagclip)"
+        },
+        {
             "fileName": "who-cdash",
-            "displayName": "Who% (Crystal Heart)"
+            "displayName": "Who% (Crystal Heart)",
+            "data": {
+                "routeNotesURL": "https://pastebin.com/eJXi1DEH"
+            }
         },
         {
             "fileName": "who-wings",
-            "displayName": "Who% (Monarch Wings)"
+            "displayName": "Who% (Monarch Wings)",
+            "data": {
+                "routeNotesURL": "https://pastebin.com/eJXi1DEH"
+            }
         },
         {
             "fileName": "witness",

--- a/src/asset/hollowknight/categories/who-ag.json
+++ b/src/asset/hollowknight/categories/who-ag.json
@@ -2,5 +2,5 @@
     "categoryName": "Who%",
     "splitIds": ["BenchAny", "GrubQueensGardensUpper"],
     "endTriggeringAutosplit": true,
-    "gameName": "Hollow Knight"
+    "gameName": "Hollow Knight Category Extensions"
 }

--- a/src/asset/hollowknight/categories/who-nmms-1028.json
+++ b/src/asset/hollowknight/categories/who-nmms-1028.json
@@ -1,0 +1,9 @@
+{
+    "categoryName": "Who%",
+    "splitIds": ["KingsPass", "VengefulSpirit", "Grub1"],
+    "names": {
+        "Grub1": "Grub Queen's Gardens Upper"
+    },
+    "endTriggeringAutosplit": true,
+    "gameName": "Hollow Knight Category Extensions"
+}

--- a/src/asset/hollowknight/categories/who-nmms-itemless.json
+++ b/src/asset/hollowknight/categories/who-nmms-itemless.json
@@ -1,0 +1,9 @@
+{
+    "categoryName": "Who%",
+    "splitIds": ["FungalWastesEntry", "QueensStationStation", "Grub1"],
+    "names": {
+        "Grub1": "Grub Queen's Gardens Upper"
+    },
+    "endTriggeringAutosplit": true,
+    "gameName": "Hollow Knight Category Extensions"
+}


### PR DESCRIPTION
Adding the two nmms routes, as well as route notes for the two nmg routes.
I don't think route notes for ag or either nmms route make much sense. AG is very short and very standard. 1028 nmms is very standard except for one hard skip at the end. Itemless nmms is the same as the newest any% nmms except for three rooms at the end (and besides, I don't think anyone other than me will ever run that route).