### PR TITLE
Moved all route notes over to github

### DIFF
--- a/src/asset/hollowknight/categories/category-directory.json
+++ b/src/asset/hollowknight/categories/category-directory.json
@@ -91,9 +91,7 @@
             "displayName": "All Skills (Emilitia)",
             "data": {
                 "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Skills%20(Emilitia).md",
-                "searchTerms": [
-                    "Eternal"
-                ]
+                "searchTerms": ["Eternal"]
             }
         },
         {
@@ -193,10 +191,7 @@
             "displayName": "True Ending (1.4.3.2+ SCSB)",
             "data": {
                 "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/True%20Ending%20(1.4.3.2%2B%20SCSB).md",
-                "searchTerms": [
-                    "soul catcher",
-                    "steady body"
-                ]
+                "searchTerms": ["soul catcher", "steady body"]
             }
         },
         {
@@ -210,10 +205,7 @@
             "displayName": "112% APB (All Glitches)",
             "data": {
                 "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/112%25%20APB%20(All%20Glitches).md",
-                "searchTerms": [
-                    "112",
-                    "ag"
-                ]
+                "searchTerms": ["112", "ag"]
             }
         },
         {
@@ -221,9 +213,7 @@
             "displayName": "All Skills (All Glitches)",
             "data": {
                 "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Skills%20(All%20Glitches).md",
-                "searchTerms": [
-                    "ag"
-                ]
+                "searchTerms": ["ag"]
             }
         },
         {
@@ -238,77 +228,56 @@
             "fileName": "any-ag",
             "displayName": "Any% (All Glitches)",
             "data": {
-                "searchTerms": [
-                    "ag"
-                ]
+                "searchTerms": ["ag"]
             }
         },
         {
             "fileName": "any-nmms",
             "displayName": "Any% (No Main Menu Storage)",
             "data": {
-                "searchTerms": [
-                    "nmms"
-                ]
+                "searchTerms": ["nmms"]
             }
         },
         {
             "fileName": "any-nmms-1028",
             "displayName": "Any% (NMMS 1.0.2.8)",
             "data": {
-                "searchTerms": [
-                    "nmms"
-                ]
+                "searchTerms": ["nmms"]
             }
         },
         {
             "fileName": "low-ag",
             "displayName": "Low% (All Glitches)",
             "data": {
-                "searchTerms": [
-                    "low",
-                    "ag"
-                ]
+                "searchTerms": ["low", "ag"]
             }
         },
         {
             "fileName": "low-nmms",
             "displayName": "Low% (No Main Menu Storage)",
             "data": {
-                "searchTerms": [
-                    "low",
-                    "nmms"
-                ]
+                "searchTerms": ["low", "nmms"]
             }
         },
         {
             "fileName": "te-ag",
             "displayName": "True Ending (All Glitches)",
             "data": {
-                "searchTerms": [
-                    "te",
-                    "ag"
-                ]
+                "searchTerms": ["te", "ag"]
             }
         },
         {
             "fileName": "te-ag-dupeless",
             "displayName": "True Ending (All Glitches, Dupeless)",
             "data": {
-                "searchTerms": [
-                    "te",
-                    "ag"
-                ]
+                "searchTerms": ["te", "ag"]
             }
         },
         {
             "fileName": "te-nmms",
             "displayName": "True Ending (No Main Menu Storage)",
             "data": {
-                "searchTerms": [
-                    "te",
-                    "nmms"
-                ]
+                "searchTerms": ["te", "nmms"]
             }
         }
     ],
@@ -381,9 +350,7 @@
             "fileName": "room-timer",
             "displayName": "Room Timer",
             "data": {
-                "searchTerms": [
-                    "Abyss Climb"
-                ]
+                "searchTerms": ["Abyss Climb"]
             }
         }
     ],
@@ -501,10 +468,7 @@
             "displayName": "16 Mask Shards",
             "data": {
                 "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/16%20Mask%20Shards.md",
-                "searchTerms": [
-                    "All",
-                    "Skulls"
-                ]
+                "searchTerms": ["All", "Skulls"]
             }
         },
         {
@@ -525,11 +489,7 @@
             "fileName": "agag",
             "displayName": "All Grubs All Glitches",
             "data": {
-                "searchTerms": [
-                    "ag",
-                    "agag",
-                    "elegy"
-                ],
+                "searchTerms": ["ag", "agag", "elegy"],
                 "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Grubs%20All%20Glitches.md"
             }
         },
@@ -566,10 +526,7 @@
             "displayName": "ACN No Shop Charms",
             "data": {
                 "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/ACN%20No%20Shop%20Charms.md",
-                "searchTerms": [
-                    "All",
-                    "Notches"
-                ]
+                "searchTerms": ["All", "Notches"]
             }
         },
         {
@@ -640,9 +597,7 @@
             "fileName": "a1uba",
             "displayName": "A1uba%",
             "data": {
-                "searchTerms": [
-                    "Aluba"
-                ]
+                "searchTerms": ["Aluba"]
             }
         },
         {
@@ -650,9 +605,7 @@
             "displayName": "Al2ba%",
             "data": {
                 "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Al2ba%25.md",
-                "searchTerms": [
-                    "Aluba"
-                ]
+                "searchTerms": ["Aluba"]
             }
         },
         {
@@ -686,10 +639,7 @@
             "displayName": "Elderbug%",
             "data": {
                 "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Elderbug%25.md",
-                "searchTerms": [
-                    "Delicate",
-                    "Flower"
-                ]
+                "searchTerms": ["Delicate", "Flower"]
             }
         },
         {
@@ -704,10 +654,7 @@
             "displayName": "Empty Hall",
             "data": {
                 "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Empty%20Hall.md",
-                "searchTerms": [
-                    "Godhome",
-                    "Gods"
-                ]
+                "searchTerms": ["Godhome", "Gods"]
             }
         },
         {
@@ -727,9 +674,7 @@
             "displayName": "Eternal Ordeal% 1mg",
             "data": {
                 "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Eternal%20Ordeal%25%201mg.md",
-                "searchTerms": [
-                    "Zote"
-                ]
+                "searchTerms": ["Zote"]
             }
         },
         {
@@ -763,10 +708,7 @@
             "displayName": "Florist",
             "data": {
                 "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Florist.md",
-                "searchTerms": [
-                    "Delicate",
-                    "Flower"
-                ]
+                "searchTerms": ["Delicate", "Flower"]
             }
         },
         {
@@ -781,9 +723,7 @@
             "displayName": "GPZ%",
             "data": {
                 "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/GPZ%25.md",
-                "searchTerms": [
-                    "Zote"
-                ]
+                "searchTerms": ["Zote"]
             }
         },
         {
@@ -942,19 +882,14 @@
             "displayName": "Salubra's Blessing%",
             "data": {
                 "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Salubra's%20Blessing%25.md",
-                "searchTerms": [
-                    "Smooch"
-                ]
+                "searchTerms": ["Smooch"]
             }
         },
         {
             "fileName": "sbaco",
             "displayName": "Salubra's Blessing% ACO",
             "data": {
-                "searchTerms": [
-                    "Smooch",
-                    "Alphabetical Charm Order"
-                ]
+                "searchTerms": ["Smooch", "Alphabetical Charm Order"]
             }
         },
         {
@@ -962,10 +897,7 @@
             "displayName": "Salubra's Blessing% CMO",
             "data": {
                 "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Salubra's%20Blessing%25%20CMO.md",
-                "searchTerms": [
-                    "Smooch",
-                    "Charm Menu Order"
-                ]
+                "searchTerms": ["Smooch", "Charm Menu Order"]
             }
         },
         {
@@ -973,10 +905,7 @@
             "displayName": "Salubra's Blessing% ICO",
             "data": {
                 "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Salubra's%20Blessing%25%20ICO.md",
-                "searchTerms": [
-                    "Smooch",
-                    "Intended Charm Order"
-                ]
+                "searchTerms": ["Smooch", "Intended Charm Order"]
             }
         },
         {
@@ -1070,9 +999,7 @@
             "displayName": "Witness",
             "data": {
                 "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Witness.md",
-                "searchTerms": [
-                    "Quirrel"
-                ]
+                "searchTerms": ["Quirrel"]
             }
         },
         {

--- a/src/asset/hollowknight/categories/category-directory.json
+++ b/src/asset/hollowknight/categories/category-directory.json
@@ -1,1014 +1,1086 @@
 {
-    "Main": [
-        {
-            "fileName": "106",
-            "displayName": "106% TE",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/mw02X1Dz"
-            }
-        },
-        {
-            "fileName": "107-comsob",
-            "displayName": "107% AB (comsob splits)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/6qmm9gwv"
-            }
-        },
-        {
-            "fileName": "107-everything",
-            "displayName": "107% AB (all splits)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/6qmm9gwv"
-            }
-        },
-        {
-            "fileName": "112-comsob-late-fury",
-            "displayName": "112% APB (comsob splits)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/mMfMLDjA"
-            }
-        },
-        {
-            "fileName": "112-everything-late-fury",
-            "displayName": "112% APB (all splits)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/mMfMLDjA"
-            }
-        },
-        {
-            "fileName": "all-achievements",
-            "displayName": "All Achievements",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/GCEmtF8b"
-            }
-        },
-        {
-            "fileName": "all-bosses-base-game",
-            "displayName": "All Bosses (Base Game)"
-        },
-        {
-            "fileName": "all-bosses-hidden-dreams",
-            "displayName": "All Bosses (Hidden Dreams)"
-        },
-        {
-            "fileName": "all-bosses-grimm-troupe",
-            "displayName": "All Bosses (Grimm Troupe)"
-        },
-        {
-            "fileName": "all-bosses-lifeblood",
-            "displayName": "All Bosses (Lifeblood)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/fMhC3FuN"
-            }
-        },
-        {
-            "fileName": "all-skills",
-            "displayName": "All Skills",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/BdT76Erg"
-            }
-        },
-        {
-            "fileName": "all-skills-fury",
-            "displayName": "All Skills (1.2.2.1 Fury/iBaldur)"
-        },
-        {
-            "fileName": "all-skills-old-route",
-            "displayName": "All Skills (Old Route)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/X2kivfc0"
-            }
-        },
-        {
-            "fileName": "all-skills-1432plus",
-            "displayName": "All Skills (1.4.3.2+)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/qKynDRaa"
-            }
-        },
-        {
-            "fileName": "all-skills-emilitia",
-            "displayName": "All Skills (Emilitia)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/T2xs1RkG",
-                "searchTerms": ["Eternal"]
-            }
-        },
-        {
-            "fileName": "any",
-            "displayName": "Any% (1.2.2.1)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/ghBveKPt"
-            }
-        },
-        {
-            "fileName": "any-shade-soul",
-            "displayName": "Any% (1.2.2.1 Shade Soul)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/bbZG17xJ"
-            }
-        },
-        {
-            "fileName": "any-fury",
-            "displayName": "Any% (1.2.2.1 Fury/iBaldur)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/pHY57siy"
-            }
-        },
-        {
-            "fileName": "any-1432plus",
-            "displayName": "Any% (1.4.3.2+ QGA)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/zKke8sDC"
-            }
-        },
-        {
-            "fileName": "any-1432plus-shade-soul",
-            "displayName": "Any% (1.4.3.2+ Shade Soul)",
-            "data": {
-                "routeNotesURL": "https://www.speedrun.com/hollowknight/guide/p2d5f"
-            }
-        },
-        {
-            "fileName": "any-1432plus-spore",
-            "displayName": "Any% (1.4.3.2+ Spore Shroom/Deepnest)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/zKke8sDC"
-            }
-        },
-        {
-            "fileName": "any-1432plus-isma",
-            "displayName": "Any% (1.4.3.2+ Isma's Tear)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/5wu2bjkP",
-                "searchTerms": [
-                    "stallball",
-                    "slopeball",
-                    "magalore",
-                    "mag isma"
-                ]
-            }
-        },
-        {
-            "fileName": "any-ss",
-            "displayName": "Any% Steel Soul",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/B9QT22zE"
-            }
-        },
-        {
-            "fileName": "any-blossom",
-            "displayName": "Any% (Blossom Edition)"
-        },
-        {
-            "fileName": "godhome-ending",
-            "displayName": "Godhome Ending"
-        },
-        {
-            "fileName": "low",
-            "displayName": "Low%",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/sb5iu8VA"
-            }
-        },
-        {
-            "fileName": "low-1432plus",
-            "displayName": "Low% (1.4.3.2+)"
-        },
-        {
-            "fileName": "te",
-            "displayName": "True Ending",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/raQmK7xC"
-            }
-        },
-        {
-            "fileName": "te-fury",
-            "displayName": "True Ending (1.2.2.1 Fury/iBaldur)"
-        },
-        {
-            "fileName": "te-1432plus",
-            "displayName": "True Ending (1.4.3.2+ SCSB)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/bfru1T23",
-                "searchTerms": ["soul catcher", "steady body"]
-            }
-        },
-        {
-            "fileName": "te-flukamoth",
-            "displayName": "True Ending (\"Flukamoth\")"
-        }
-    ],
-    "Glitched": [
-        {
-            "fileName": "112-ag",
-            "displayName": "112% APB (All Glitches)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/Gz0NMk98",
-                "searchTerms": ["112", "ag"]
-            }
-        },
-        {
-            "fileName": "all-skills-ag",
-            "displayName": "All Skills (All Glitches)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/7RD8WkqX",
-                "searchTerms": ["ag"]
-            }
-        },
-        {
-            "fileName": "all-bosses-hidden-dreams-nmms",
-            "displayName": "All Bosses (Hidden Dreams, NMMS)"
-        },
-        {
-            "fileName": "all-bosses-grimm-troupe-nmms",
-            "displayName": "All Bosses (Grimm Troupe, NMMS)"
-        },
-        {
-            "fileName": "any-ag",
-            "displayName": "Any% (All Glitches)",
-            "data": {
-                "searchTerms": ["ag"]
-            }
-        },
-        {
-            "fileName": "any-nmms",
-            "displayName": "Any% (No Main Menu Storage)",
-            "data": {
-                "searchTerms": ["nmms"]
-            }
-        },
-        {
-            "fileName": "any-nmms-1028",
-            "displayName": "Any% (NMMS 1.0.2.8)",
-            "data": {
-                "searchTerms": ["nmms"]
-            }
-        },
-        {
-            "fileName": "low-ag",
-            "displayName": "Low% (All Glitches)",
-            "data": {
-                "searchTerms": ["low", "ag"]
-            }
-        },
-        {
-            "fileName": "low-nmms",
-            "displayName": "Low% (No Main Menu Storage)",
-            "data": {
-                "searchTerms": ["low", "nmms"]
-            }
-        },
-        {
-            "fileName": "te-ag",
-            "displayName": "True Ending (All Glitches)",
-            "data": {
-                "searchTerms": ["te", "ag"]
-            }
-        },
-        {
-            "fileName": "te-ag-dupeless",
-            "displayName": "True Ending (All Glitches, Dupeless)",
-            "data": {
-                "searchTerms": ["te", "ag"]
-            }
-        },
-        {
-            "fileName": "te-nmms",
-            "displayName": "True Ending (No Main Menu Storage)",
-            "data": {
-                "searchTerms": ["te", "nmms"]
-            }
-        }
-    ],
-    "Individual Level": [
-        {
-            "fileName": "colo1",
-            "displayName": "Trial of the Warrior (colo1)"
-        },
-        {
-            "fileName": "colo1-waves",
-            "displayName": "Colo 1 w/ Autosplit Waves"
-        },
-        {
-            "fileName": "colo2",
-            "displayName": "Trial of the Conqueror (colo2)"
-        },
-        {
-            "fileName": "colo2-waves",
-            "displayName": "Colo 2 w/ Autosplit Waves"
-        },
-        {
-            "fileName": "colo3",
-            "displayName": "Trial of the Fool (colo3)"
-        },
-        {
-            "fileName": "colo3-waves",
-            "displayName": "Colo 3 w/ Autosplit Waves"
-        },
-        {
-            "fileName": "kp",
-            "displayName": "King's Pass"
-        },
-        {
-            "fileName": "menderbug",
-            "displayName": "Menderbug%"
-        },
-        {
-            "fileName": "p1",
-            "displayName": "Pantheon of the Master (P1)"
-        },
-        {
-            "fileName": "p2",
-            "displayName": "Pantheon of the Artist (P2)"
-        },
-        {
-            "fileName": "p3",
-            "displayName": "Pantheon of the Sage (P3)"
-        },
-        {
-            "fileName": "p4",
-            "displayName": "Pantheon of the Knight (P4)"
-        },
-        {
-            "fileName": "p5",
-            "displayName": "Pantheon of Hallownest (P5)"
-        },
-        {
-            "fileName": "pop",
-            "displayName": "Path of Pain"
-        },
-        {
-            "fileName": "wp",
-            "displayName": "White Palace"
-        },
-        {
-            "fileName": "wp-1315plus",
-            "displayName": "White Palace IL (1.3.1.5+)"
-        },
-        {
-            "fileName": "room-timer",
-            "displayName": "Room Timer",
-            "data": {
-                "searchTerms": ["Abyss Climb"]
-            }
-        }
-    ],
-    "Mods": [
-        {
-            "fileName": "all-geo-rocks",
-            "displayName": "All Geo Rocks",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/PQwrtcn7"
-            }
-        },
-        {
-            "fileName": "fc-as-te",
-            "displayName": "Forgotten Corners AS TE",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/BqgW7arm"
-            }
-        },
-        {
-            "fileName": "grass",
-            "displayName": "Grass%",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/jJ7Kp7fd"
-            }
-        },
-        {
-            "fileName": "kronk",
-            "displayName": "Kronk%",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/LgsqmyTT"
-            }
-        },
-        {
-            "fileName": "myla-flower",
-            "displayName": "Myla Flower",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/Jfip4P4Z"
-            }
-        },
-        {
-            "fileName": "low-ab",
-            "displayName": "Low% All Bindings",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/iX1FkYqm"
-            }
-        },
-        {
-            "fileName": "rando-te",
-            "displayName": "Randomizer TE (add splits as desired)"
-        }
-    ],
-    "Category Extensions": [
-        {
-            "fileName": "0geo",
-            "displayName": "0 Geo",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/ExnadfJn"
-            }
-        },
-        {
-            "fileName": "3vf-kings-station",
-            "displayName": "3 Vessel Fragments (King's Station)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/ZqDk8rQ0"
-            }
-        },
-        {
-            "fileName": "3vf-stag-nest",
-            "displayName": "3 Vessel Fragments (Stag Nest)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/4mE0UWtG"
-            }
-        },
-        {
-            "fileName": "worldsoul",
-            "displayName": "Worldsoul (9 Vessel Fragments)"
-        },
-        {
-            "fileName": "4ms",
-            "displayName": "4 Mask Shards",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/YZf8CZAd"
-            }
-        },
-        {
-            "fileName": "4ms-0geo",
-            "displayName": "4 Mask Shards 0 Geo",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/9VGYYnxq"
-            }
-        },
-        {
-            "fileName": "8ms",
-            "displayName": "8 Mask Shards",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/ptWLryuc"
-            }
-        },
-        {
-            "fileName": "8ms-fc-stag",
-            "displayName": "8 Mask Shards (FC Stag Route)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/fTb71NVd"
-            }
-        },
-        {
-            "fileName": "12ms",
-            "displayName": "12 Mask Shards",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/RUmPctix"
-            }
-        },
-        {
-            "fileName": "16ms",
-            "displayName": "16 Mask Shards",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/2cRkecGU",
-                "searchTerms": ["All", "Skulls"]
-            }
-        },
-        {
-            "fileName": "5-mimics",
-            "displayName": "5 Mimics",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/0KVWK3cg"
-            }
-        },
-        {
-            "fileName": "100-completion",
-            "displayName": "100% Completion",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/dcNJnwbX"
-            }
-        },
-        {
-            "fileName": "agag",
-            "displayName": "All Grubs All Glitches",
-            "data": {
-                "searchTerms": ["ag", "agag", "elegy"],
-                "routeNotesURL": "https://pastebin.com/B71Ziajz"
-            }
-        },
-        {
-            "fileName": "all-broken-charms",
-            "displayName": "All Broken Charms",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/8sAnv8Um"
-            }
-        },
-        {
-            "fileName": "all-dream-bosses-1432plus",
-            "displayName": "All Dream Bosses (1.4.3.2+, flukes)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/JxhZDmpi"
-            }
-        },
-        {
-            "fileName": "acn",
-            "displayName": "All Charm Notches",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/NU38A5Jc"
-            }
-        },
-        {
-            "fileName": "acn-1221",
-            "displayName": "All Charm Notches (1.2.2.1)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/xAES68kr"
-            }
-        },
-        {
-            "fileName": "acnnsc",
-            "displayName": "ACN No Shop Charms",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/JpmPf3A5",
-                "searchTerms": ["All", "Notches"]
-            }
-        },
-        {
-            "fileName": "acnkgpz",
-            "displayName": "ACNKGPZ%",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/T4kvc18m"
-            }
-        },
-        {
-            "fileName": "all-geo-chests",
-            "displayName": "All Geo Chests",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/UQkWAn9X"
-            }
-        },
-        {
-            "fileName": "all-hallownest-seals",
-            "displayName": "All Hallownest Seals",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/9TvBf2QB"
-            }
-        },
-        {
-            "fileName": "all-keys",
-            "displayName": "All Keys",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/yEQRU9zw"
-            }
-        },
-        {
-            "fileName": "all-kings-idols",
-            "displayName": "All King's Idols",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/DtjmS4JC"
-            }
-        },
-        {
-            "fileName": "all-stag-stations",
-            "displayName": "All Stag Stations",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/s0QyY7UE"
-            }
-        },
-        {
-            "fileName": "all-unbreakable-charms",
-            "displayName": "All Unbreakable Charms"
-        },
-        {
-            "fileName": "all-unbreakable-charms-ss",
-            "displayName": "All Unbreakable Charms (Steel Soul)"
-        },
-        {
-            "fileName": "all-wanderers-journals",
-            "displayName": "All Wanderer's Journals",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/smQ1fmzM"
-            }
-        },
-        {
-            "fileName": "all-whispering-roots",
-            "displayName": "All Whispering Roots",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/jyQ1JnPf"
-            }
-        },
-        {
-            "fileName": "a1uba",
-            "displayName": "A1uba%",
-            "data": {
-                "searchTerms": ["Aluba"]
-            }
-        },
-        {
-            "fileName": "al2ba",
-            "displayName": "Al2ba%",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/j3i4uV16",
-                "searchTerms": ["Aluba"]
-            }
-        },
-        {
-            "fileName": "cartographer",
-            "displayName": "Cartographer",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/DMHJxF7x",
-                "searchTerms": [
-                    "Dapper",
-                    "Mapper",
-                    "all",
-                    "maps",
-                    "Cornifer",
-                    "Iselda"
-                ]
-            }
-        },
-        {
-            "fileName": "clawless-shade-cloak",
-            "displayName": "Clawless Shade Cloak (CSC)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/YJA6JqB1"
-            }
-        },
-        {
-            "fileName": "eat-me-too",
-            "displayName": "Eat Me Too"
-        },
-        {
-            "fileName": "elderbug",
-            "displayName": "Elderbug%",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/TCxBpEj1",
-                "searchTerms": ["Delicate", "Flower"]
-            }
-        },
-        {
-            "fileName": "elegy",
-            "displayName": "Elegy%",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/WCpZnRU1"
-            }
-        },
-        {
-            "fileName": "empty-hall",
-            "displayName": "Empty Hall",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/fH7xjsau",
-                "searchTerms": ["Godhome", "Gods"]
-            }
-        },
-        {
-            "fileName": "egg",
-            "displayName": "Egg (21)"
-        },
-        {
-            "fileName": "egg-101",
-            "displayName": "Egg (101)"
-        },
-        {
-            "fileName": "enraged-guardian",
-            "displayName": "Enraged Guardian%"
-        },
-        {
-            "fileName": "eternal-ordeal-1mg",
-            "displayName": "Eternal Ordeal% 1mg",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/uB3unPih",
-                "searchTerms": ["Zote"]
-            }
-        },
-        {
-            "fileName": "fool-1221",
-            "displayName": "Fool% (1.2.2.1)",
-            "data": {
-                "routeNotesURL": "https://youtu.be/dQw4w9WgXcQ"
-            }
-        },
-        {
-            "fileName": "ggg",
-            "displayName": "Gaslight, Gatekeep, Girlboss",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/hVCNQkuJ",
-                "searchTerms": [
-                    "City Crest",
-                    "Nightmare Lantern",
-                    "Eternal Emilitia"
-                ]
-            }
-        },
-        {
-            "fileName": "grubsong",
-            "displayName": "Grubsong%",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/4nK0dMSp"
-            }
-        },
-        {
-            "fileName": "florist",
-            "displayName": "Florist",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/eXNyLRmh",
-                "searchTerms": ["Delicate", "Flower"]
-            }
-        },
-        {
-            "fileName": "ghostbusters",
-            "displayName": "Ghostbusters",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/APnciDfV"
-            }
-        },
-        {
-            "fileName": "gpz",
-            "displayName": "GPZ%",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/EfggmK5Q",
-                "searchTerms": ["Zote"]
-            }
-        },
-        {
-            "fileName": "great-hopper",
-            "displayName": "Great Hopper%",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/FwtGJx9m"
-            }
-        },
-        {
-            "fileName": "godhome",
-            "displayName": "Godhome (Godseeker mode)"
-        },
-        {
-            "fileName": "happy-couple",
-            "displayName": "Happy Couple",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/s0wpmmvw"
-            }
-        },
-        {
-            "fileName": "happy-couple-1221",
-            "displayName": "Happy Couple (1.2.2.1)"
-        },
-        {
-            "fileName": "hiveblood",
-            "displayName": "Hiveblood%",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/QN4szmEy"
-            }
-        },
-        {
-            "fileName": "lbc",
-            "displayName": "Lifeblood Core%"
-        },
-        {
-            "fileName": "low-te-dropless",
-            "displayName": "Low% True Ending Dropless",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/pSCAkfgW"
-            }
-        },
-        {
-            "fileName": "marissa-audience",
-            "displayName": "Marissa Audience",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/j2NPwzMi"
-            }
-        },
-        {
-            "fileName": "marmu",
-            "displayName": "Marmu%"
-        },
-        {
-            "fileName": "max-0-geo",
-            "displayName": "Max% 0 Geo",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/SteEqbXY"
-            }
-        },
-        {
-            "fileName": "mr-mushroom-ending",
-            "displayName": "Mr. Mushroom Ending",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/u2yHq1FA"
-            }
-        },
-        {
-            "fileName": "myla",
-            "displayName": "Myla%",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/R32n9tRe"
-            }
-        },
-        {
-            "fileName": "mylas-revenge",
-            "displayName": "Myla's Revenge",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/6GpVtNaC"
-            }
-        },
-        {
-            "fileName": "nice",
-            "displayName": "Nice%",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/PKM4PqKV"
-            }
-        },
-        {
-            "fileName": "nice-1221",
-            "displayName": "Nice% (1.2.2.1)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/yZ198TnD"
-            }
-        },
-        {
-            "fileName": "nkg",
-            "displayName": "NKG%",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/1NXTh6BN"
-            }
-        },
-        {
-            "fileName": "nkg-nmms",
-            "displayName": "NKG% (No Main Menu Storage)",
-            "data": {}
-        },
-        {
-            "fileName": "nmg",
-            "displayName": "NMG%"
-        },
-        {
-            "fileName": "nosk",
-            "displayName": "Nosk%",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/6kFcaZUM"
-            }
-        },
-        {
-            "fileName": "pop-percent",
-            "displayName": "Path of Pain%",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/KZSZd7XE"
-            }
-        },
-        {
-            "fileName": "pure-snail",
-            "displayName": "Pure Snail",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/ZZq1bzz3"
-            }
-        },
-        {
-            "fileName": "p5bo",
-            "displayName": "Pantheon 5 Boss Order",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/58nWJpE6"
-            }
-        },
-        {
-            "fileName": "p5bo-breaks",
-            "displayName": "Pantheon 5 Boss Order (w/ breaks)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/58nWJpE6"
-            }
-        },
-        {
-            "fileName": "round",
-            "displayName": "Round%",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/6WZT44bf"
-            }
-        },
-        {
-            "fileName": "salubras-blessing",
-            "displayName": "Salubra's Blessing%",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/1246ZqXH",
-                "searchTerms": ["Smooch"]
-            }
-        },
-        {
-            "fileName": "sbaco",
-            "displayName": "Salubra's Blessing% ACO",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/1xMa3mBR",
-                "searchTerms": ["Smooch", "Alphabetical Charm Order"]
-            }
-        },
-        {
-            "fileName": "sbcmo",
-            "displayName": "Salubra's Blessing% CMO",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/Q17WZ3Ra",
-                "searchTerms": ["Smooch", "Charm Menu Order"]
-            }
-        },
-        {
-            "fileName": "sbico",
-            "displayName": "Salubra's Blessing% ICO",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/9YKFHHiG",
-                "searchTerms": ["Smooch", "Intended Charm Order"]
-            }
-        },
-        {
-            "fileName": "save-myla",
-            "displayName": "Save Myla (Dash Slash route)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/RHZz4apd"
-            }
-        },
-        {
-            "fileName": "shriek",
-            "displayName": "Shriek%",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/JuvF7pqZ"
-            }
-        },
-        {
-            "fileName": "stinky",
-            "displayName": "Stinky% Comfy",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/xY2pJxyf"
-            }
-        },
-        {
-            "fileName": "spelless",
-            "displayName": "Spelless",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/QLp4NfEG"
-            }
-        },
-        {
-            "fileName": "spelless-dreamshield",
-            "displayName": "Spelless (Dreamshield)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/ZsLAeKAD"
-            }
-        },
-        {
-            "fileName": "spelless-low",
-            "displayName": "Low% Spelless"
-        },
-        {
-            "fileName": "spelless-te",
-            "displayName": "Spelless True Ending",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/xShXaS4e"
-            }
-        },
-        {
-            "fileName": "spelless-te-dreamshield",
-            "displayName": "Spelless True Ending (Dreamshield)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/Quwr2dTM"
-            }
-        },
-        {
-            "fileName": "spinach",
-            "displayName": "SPINACH%",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/7p0JjkCJ"
-            }
-        },
-        {
-            "fileName": "who-ag",
-            "displayName": "Who% (All Glitches)"
-        },
-        {
-            "fileName": "who-nmms-1028",
-            "displayName": "Who% (No Main Menu Storage, 1028)"
-        },
-        {
-            "fileName": "who-nmms-itemless",
-            "displayName": "Who% (No Main Menu Storage, itemless stagclip)"
-        },
-        {
-            "fileName": "who-cdash",
-            "displayName": "Who% (Crystal Heart)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/eJXi1DEH"
-            }
-        },
-        {
-            "fileName": "who-wings",
-            "displayName": "Who% (Monarch Wings)",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/eJXi1DEH"
-            }
-        },
-        {
-            "fileName": "witness",
-            "displayName": "Witness",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/Eh3w66CQ",
-                "searchTerms": ["Quirrel"]
-            }
-        },
-        {
-            "fileName": "zote",
-            "displayName": "Zote%",
-            "data": {
-                "routeNotesURL": "https://pastebin.com/KWYVyfn7"
-            }
-        }
-    ]
+  "Main": [
+    {
+      "fileName": "106",
+      "displayName": "106% TE",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/106%25%20TE.md"
+      }
+    },
+    {
+      "fileName": "107-comsob",
+      "displayName": "107% AB (comsob splits)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/107%25%20AB%20(comsob%20splits).md"
+      }
+    },
+    {
+      "fileName": "107-everything",
+      "displayName": "107% AB (all splits)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/107%25%20AB%20(all%20splits).md"
+      }
+    },
+    {
+      "fileName": "112-comsob-late-fury",
+      "displayName": "112% APB (comsob splits)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/112%25%20APB%20(comsob%20splits).md"
+      }
+    },
+    {
+      "fileName": "112-everything-late-fury",
+      "displayName": "112% APB (all splits)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/112%25%20APB%20(all%20splits).md"
+      }
+    },
+    {
+      "fileName": "all-achievements",
+      "displayName": "All Achievements",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Achievements.md"
+      }
+    },
+    {
+      "fileName": "all-bosses-base-game",
+      "displayName": "All Bosses (Base Game)"
+    },
+    {
+      "fileName": "all-bosses-hidden-dreams",
+      "displayName": "All Bosses (Hidden Dreams)"
+    },
+    {
+      "fileName": "all-bosses-grimm-troupe",
+      "displayName": "All Bosses (Grimm Troupe)"
+    },
+    {
+      "fileName": "all-bosses-lifeblood",
+      "displayName": "All Bosses (Lifeblood)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Bosses%20(Lifeblood).md"
+      }
+    },
+    {
+      "fileName": "all-skills",
+      "displayName": "All Skills",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Skills.md"
+      }
+    },
+    {
+      "fileName": "all-skills-fury",
+      "displayName": "All Skills (1.2.2.1 Fury/iBaldur)"
+    },
+    {
+      "fileName": "all-skills-old-route",
+      "displayName": "All Skills (Old Route)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Skills%20(Old%20Route).md"
+      }
+    },
+    {
+      "fileName": "all-skills-1432plus",
+      "displayName": "All Skills (1.4.3.2+)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Skills%20(1.4.3.2%2B).md"
+      }
+    },
+    {
+      "fileName": "all-skills-emilitia",
+      "displayName": "All Skills (Emilitia)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Skills%20(Emilitia).md",
+        "searchTerms": [
+          "Eternal"
+        ]
+      }
+    },
+    {
+      "fileName": "any",
+      "displayName": "Any% (1.2.2.1)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Any%25%20(1.2.2.1).md"
+      }
+    },
+    {
+      "fileName": "any-shade-soul",
+      "displayName": "Any% (1.2.2.1 Shade Soul)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Any%25%20(1.2.2.1%20Shade%20Soul).md"
+      }
+    },
+    {
+      "fileName": "any-fury",
+      "displayName": "Any% (1.2.2.1 Fury/iBaldur)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Any%25%20(1.2.2.1%20Fury%EF%BC%8FiBaldur).md"
+      }
+    },
+    {
+      "fileName": "any-1432plus",
+      "displayName": "Any% (1.4.3.2+ QGA)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Any%25%20(1.4.3.2%2B%20QGA).md"
+      }
+    },
+    {
+      "fileName": "any-1432plus-shade-soul",
+      "displayName": "Any% (1.4.3.2+ Shade Soul)",
+      "data": {
+        "routeNotesURL": "https://www.speedrun.com/hollowknight/guide/p2d5f"
+      }
+    },
+    {
+      "fileName": "any-1432plus-spore",
+      "displayName": "Any% (1.4.3.2+ Spore Shroom/Deepnest)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Any%25%20(1.4.3.2%2B%20Spore%20Shroom%EF%BC%8FDeepnest).md"
+      }
+    },
+    {
+      "fileName": "any-1432plus-isma",
+      "displayName": "Any% (1.4.3.2+ Isma's Tear)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Any%25%20(1.4.3.2%2B%20Isma's%20Tear).md",
+        "searchTerms": [
+          "stallball",
+          "slopeball",
+          "magalore",
+          "mag isma"
+        ]
+      }
+    },
+    {
+      "fileName": "any-ss",
+      "displayName": "Any% Steel Soul",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Any%25%20Steel%20Soul.md"
+      }
+    },
+    {
+      "fileName": "any-blossom",
+      "displayName": "Any% (Blossom Edition)"
+    },
+    {
+      "fileName": "godhome-ending",
+      "displayName": "Godhome Ending"
+    },
+    {
+      "fileName": "low",
+      "displayName": "Low%",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Low%25.md"
+      }
+    },
+    {
+      "fileName": "low-1432plus",
+      "displayName": "Low% (1.4.3.2+)"
+    },
+    {
+      "fileName": "te",
+      "displayName": "True Ending",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/True%20Ending.md"
+      }
+    },
+    {
+      "fileName": "te-fury",
+      "displayName": "True Ending (1.2.2.1 Fury/iBaldur)"
+    },
+    {
+      "fileName": "te-1432plus",
+      "displayName": "True Ending (1.4.3.2+ SCSB)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/True%20Ending%20(1.4.3.2%2B%20SCSB).md",
+        "searchTerms": [
+          "soul catcher",
+          "steady body"
+        ]
+      }
+    },
+    {
+      "fileName": "te-flukamoth",
+      "displayName": "True Ending (\"Flukamoth\")"
+    }
+  ],
+  "Glitched": [
+    {
+      "fileName": "112-ag",
+      "displayName": "112% APB (All Glitches)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/112%25%20APB%20(All%20Glitches).md",
+        "searchTerms": [
+          "112",
+          "ag"
+        ]
+      }
+    },
+    {
+      "fileName": "all-skills-ag",
+      "displayName": "All Skills (All Glitches)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Skills%20(All%20Glitches).md",
+        "searchTerms": [
+          "ag"
+        ]
+      }
+    },
+    {
+      "fileName": "all-bosses-hidden-dreams-nmms",
+      "displayName": "All Bosses (Hidden Dreams, NMMS)"
+    },
+    {
+      "fileName": "all-bosses-grimm-troupe-nmms",
+      "displayName": "All Bosses (Grimm Troupe, NMMS)"
+    },
+    {
+      "fileName": "any-ag",
+      "displayName": "Any% (All Glitches)",
+      "data": {
+        "searchTerms": [
+          "ag"
+        ]
+      }
+    },
+    {
+      "fileName": "any-nmms",
+      "displayName": "Any% (No Main Menu Storage)",
+      "data": {
+        "searchTerms": [
+          "nmms"
+        ]
+      }
+    },
+    {
+      "fileName": "any-nmms-1028",
+      "displayName": "Any% (NMMS 1.0.2.8)",
+      "data": {
+        "searchTerms": [
+          "nmms"
+        ]
+      }
+    },
+    {
+      "fileName": "low-ag",
+      "displayName": "Low% (All Glitches)",
+      "data": {
+        "searchTerms": [
+          "low",
+          "ag"
+        ]
+      }
+    },
+    {
+      "fileName": "low-nmms",
+      "displayName": "Low% (No Main Menu Storage)",
+      "data": {
+        "searchTerms": [
+          "low",
+          "nmms"
+        ]
+      }
+    },
+    {
+      "fileName": "te-ag",
+      "displayName": "True Ending (All Glitches)",
+      "data": {
+        "searchTerms": [
+          "te",
+          "ag"
+        ]
+      }
+    },
+    {
+      "fileName": "te-ag-dupeless",
+      "displayName": "True Ending (All Glitches, Dupeless)",
+      "data": {
+        "searchTerms": [
+          "te",
+          "ag"
+        ]
+      }
+    },
+    {
+      "fileName": "te-nmms",
+      "displayName": "True Ending (No Main Menu Storage)",
+      "data": {
+        "searchTerms": [
+          "te",
+          "nmms"
+        ]
+      }
+    }
+  ],
+  "Individual Level": [
+    {
+      "fileName": "colo1",
+      "displayName": "Trial of the Warrior (colo1)"
+    },
+    {
+      "fileName": "colo1-waves",
+      "displayName": "Colo 1 w/ Autosplit Waves"
+    },
+    {
+      "fileName": "colo2",
+      "displayName": "Trial of the Conqueror (colo2)"
+    },
+    {
+      "fileName": "colo2-waves",
+      "displayName": "Colo 2 w/ Autosplit Waves"
+    },
+    {
+      "fileName": "colo3",
+      "displayName": "Trial of the Fool (colo3)"
+    },
+    {
+      "fileName": "colo3-waves",
+      "displayName": "Colo 3 w/ Autosplit Waves"
+    },
+    {
+      "fileName": "kp",
+      "displayName": "King's Pass"
+    },
+    {
+      "fileName": "menderbug",
+      "displayName": "Menderbug%"
+    },
+    {
+      "fileName": "p1",
+      "displayName": "Pantheon of the Master (P1)"
+    },
+    {
+      "fileName": "p2",
+      "displayName": "Pantheon of the Artist (P2)"
+    },
+    {
+      "fileName": "p3",
+      "displayName": "Pantheon of the Sage (P3)"
+    },
+    {
+      "fileName": "p4",
+      "displayName": "Pantheon of the Knight (P4)"
+    },
+    {
+      "fileName": "p5",
+      "displayName": "Pantheon of Hallownest (P5)"
+    },
+    {
+      "fileName": "pop",
+      "displayName": "Path of Pain"
+    },
+    {
+      "fileName": "wp",
+      "displayName": "White Palace"
+    },
+    {
+      "fileName": "wp-1315plus",
+      "displayName": "White Palace IL (1.3.1.5+)"
+    },
+    {
+      "fileName": "room-timer",
+      "displayName": "Room Timer",
+      "data": {
+        "searchTerms": [
+          "Abyss Climb"
+        ]
+      }
+    }
+  ],
+  "Mods": [
+    {
+      "fileName": "all-geo-rocks",
+      "displayName": "All Geo Rocks",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Geo%20Rocks.md"
+      }
+    },
+    {
+      "fileName": "fc-as-te",
+      "displayName": "Forgotten Corners AS TE",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Forgotten%20Corners%20AS%20TE.md"
+      }
+    },
+    {
+      "fileName": "grass",
+      "displayName": "Grass%",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Grass%25.md"
+      }
+    },
+    {
+      "fileName": "kronk",
+      "displayName": "Kronk%",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Kronk%25.md"
+      }
+    },
+    {
+      "fileName": "myla-flower",
+      "displayName": "Myla Flower",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Myla%20Flower.md"
+      }
+    },
+    {
+      "fileName": "low-ab",
+      "displayName": "Low% All Bindings",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Low%25%20All%20Bindings.md"
+      }
+    },
+    {
+      "fileName": "rando-te",
+      "displayName": "Randomizer TE (add splits as desired)"
+    }
+  ],
+  "Category Extensions": [
+    {
+      "fileName": "0geo",
+      "displayName": "0 Geo",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/0%20Geo.md"
+      }
+    },
+    {
+      "fileName": "3vf-kings-station",
+      "displayName": "3 Vessel Fragments (King's Station)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/3%20Vessel%20Fragments%20(King's%20Station).md"
+      }
+    },
+    {
+      "fileName": "3vf-stag-nest",
+      "displayName": "3 Vessel Fragments (Stag Nest)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/3%20Vessel%20Fragments%20(Stag%20Nest).md"
+      }
+    },
+    {
+      "fileName": "worldsoul",
+      "displayName": "Worldsoul (9 Vessel Fragments)"
+    },
+    {
+      "fileName": "4ms",
+      "displayName": "4 Mask Shards",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/4%20Mask%20Shards.md"
+      }
+    },
+    {
+      "fileName": "4ms-0geo",
+      "displayName": "4 Mask Shards 0 Geo",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/4%20Mask%20Shards%200%20Geo.md"
+      }
+    },
+    {
+      "fileName": "8ms",
+      "displayName": "8 Mask Shards",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/8%20Mask%20Shards.md"
+      }
+    },
+    {
+      "fileName": "8ms-fc-stag",
+      "displayName": "8 Mask Shards (FC Stag Route)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/8%20Mask%20Shards%20(FC%20Stag%20Route).md"
+      }
+    },
+    {
+      "fileName": "12ms",
+      "displayName": "12 Mask Shards",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/12%20Mask%20Shards.md"
+      }
+    },
+    {
+      "fileName": "16ms",
+      "displayName": "16 Mask Shards",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/16%20Mask%20Shards.md",
+        "searchTerms": [
+          "All",
+          "Skulls"
+        ]
+      }
+    },
+    {
+      "fileName": "5-mimics",
+      "displayName": "5 Mimics",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/5%20Mimics.md"
+      }
+    },
+    {
+      "fileName": "100-completion",
+      "displayName": "100% Completion",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/100%25%20Completion.md"
+      }
+    },
+    {
+      "fileName": "agag",
+      "displayName": "All Grubs All Glitches",
+      "data": {
+        "searchTerms": [
+          "ag",
+          "agag",
+          "elegy"
+        ],
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Grubs%20All%20Glitches.md"
+      }
+    },
+    {
+      "fileName": "all-broken-charms",
+      "displayName": "All Broken Charms",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Broken%20Charms.md"
+      }
+    },
+    {
+      "fileName": "all-dream-bosses-1432plus",
+      "displayName": "All Dream Bosses (1.4.3.2+, flukes)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Dream%20Bosses%20(1.4.3.2%2B%2C%20flukes).md"
+      }
+    },
+    {
+      "fileName": "acn",
+      "displayName": "All Charm Notches",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Charm%20Notches.md"
+      }
+    },
+    {
+      "fileName": "acn-1221",
+      "displayName": "All Charm Notches (1.2.2.1)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Charm%20Notches%20(1.2.2.1).md"
+      }
+    },
+    {
+      "fileName": "acnnsc",
+      "displayName": "ACN No Shop Charms",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/ACN%20No%20Shop%20Charms.md",
+        "searchTerms": [
+          "All",
+          "Notches"
+        ]
+      }
+    },
+    {
+      "fileName": "acnkgpz",
+      "displayName": "ACNKGPZ%",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/ACNKGPZ%25.md"
+      }
+    },
+    {
+      "fileName": "all-geo-chests",
+      "displayName": "All Geo Chests",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Geo%20Chests.md"
+      }
+    },
+    {
+      "fileName": "all-hallownest-seals",
+      "displayName": "All Hallownest Seals",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Hallownest%20Seals.md"
+      }
+    },
+    {
+      "fileName": "all-keys",
+      "displayName": "All Keys",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Keys.md"
+      }
+    },
+    {
+      "fileName": "all-kings-idols",
+      "displayName": "All King's Idols",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20King's%20Idols.md"
+      }
+    },
+    {
+      "fileName": "all-stag-stations",
+      "displayName": "All Stag Stations",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Stag%20Stations.md"
+      }
+    },
+    {
+      "fileName": "all-unbreakable-charms",
+      "displayName": "All Unbreakable Charms"
+    },
+    {
+      "fileName": "all-unbreakable-charms-ss",
+      "displayName": "All Unbreakable Charms (Steel Soul)"
+    },
+    {
+      "fileName": "all-wanderers-journals",
+      "displayName": "All Wanderer's Journals",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Wanderer's%20Journals.md"
+      }
+    },
+    {
+      "fileName": "all-whispering-roots",
+      "displayName": "All Whispering Roots",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Whispering%20Roots.md"
+      }
+    },
+    {
+      "fileName": "a1uba",
+      "displayName": "A1uba%",
+      "data": {
+        "searchTerms": [
+          "Aluba"
+        ]
+      }
+    },
+    {
+      "fileName": "al2ba",
+      "displayName": "Al2ba%",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Al2ba%25.md",
+        "searchTerms": [
+          "Aluba"
+        ]
+      }
+    },
+    {
+      "fileName": "cartographer",
+      "displayName": "Cartographer",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Cartographer.md",
+        "searchTerms": [
+          "Dapper",
+          "Mapper",
+          "all",
+          "maps",
+          "Cornifer",
+          "Iselda"
+        ]
+      }
+    },
+    {
+      "fileName": "clawless-shade-cloak",
+      "displayName": "Clawless Shade Cloak (CSC)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Clawless%20Shade%20Cloak%20(CSC).md"
+      }
+    },
+    {
+      "fileName": "eat-me-too",
+      "displayName": "Eat Me Too"
+    },
+    {
+      "fileName": "elderbug",
+      "displayName": "Elderbug%",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Elderbug%25.md",
+        "searchTerms": [
+          "Delicate",
+          "Flower"
+        ]
+      }
+    },
+    {
+      "fileName": "elegy",
+      "displayName": "Elegy%",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Elegy%25.md"
+      }
+    },
+    {
+      "fileName": "empty-hall",
+      "displayName": "Empty Hall",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Empty%20Hall.md",
+        "searchTerms": [
+          "Godhome",
+          "Gods"
+        ]
+      }
+    },
+    {
+      "fileName": "egg",
+      "displayName": "Egg (21)"
+    },
+    {
+      "fileName": "egg-101",
+      "displayName": "Egg (101)"
+    },
+    {
+      "fileName": "enraged-guardian",
+      "displayName": "Enraged Guardian%"
+    },
+    {
+      "fileName": "eternal-ordeal-1mg",
+      "displayName": "Eternal Ordeal% 1mg",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Eternal%20Ordeal%25%201mg.md",
+        "searchTerms": [
+          "Zote"
+        ]
+      }
+    },
+    {
+      "fileName": "fool-1221",
+      "displayName": "Fool% (1.2.2.1)",
+      "data": {
+        "routeNotesURL": "https://youtu.be/dQw4w9WgXcQ"
+      }
+    },
+    {
+      "fileName": "ggg",
+      "displayName": "Gaslight, Gatekeep, Girlboss",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Gaslight%2C%20Gatekeep%2C%20Girlboss.md",
+        "searchTerms": [
+          "City Crest",
+          "Nightmare Lantern",
+          "Eternal Emilitia"
+        ]
+      }
+    },
+    {
+      "fileName": "grubsong",
+      "displayName": "Grubsong%",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Grubsong%25.md"
+      }
+    },
+    {
+      "fileName": "florist",
+      "displayName": "Florist",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Florist.md",
+        "searchTerms": [
+          "Delicate",
+          "Flower"
+        ]
+      }
+    },
+    {
+      "fileName": "ghostbusters",
+      "displayName": "Ghostbusters",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Ghostbusters.md"
+      }
+    },
+    {
+      "fileName": "gpz",
+      "displayName": "GPZ%",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/GPZ%25.md",
+        "searchTerms": [
+          "Zote"
+        ]
+      }
+    },
+    {
+      "fileName": "great-hopper",
+      "displayName": "Great Hopper%",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Great%20Hopper%25.md"
+      }
+    },
+    {
+      "fileName": "godhome",
+      "displayName": "Godhome (Godseeker mode)"
+    },
+    {
+      "fileName": "happy-couple",
+      "displayName": "Happy Couple",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Happy%20Couple.md"
+      }
+    },
+    {
+      "fileName": "happy-couple-1221",
+      "displayName": "Happy Couple (1.2.2.1)"
+    },
+    {
+      "fileName": "hiveblood",
+      "displayName": "Hiveblood%",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Hiveblood%25.md"
+      }
+    },
+    {
+      "fileName": "lbc",
+      "displayName": "Lifeblood Core%"
+    },
+    {
+      "fileName": "low-te-dropless",
+      "displayName": "Low% True Ending Dropless",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Low%25%20True%20Ending%20Dropless.md"
+      }
+    },
+    {
+      "fileName": "marissa-audience",
+      "displayName": "Marissa Audience",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Marissa%20Audience.md"
+      }
+    },
+    {
+      "fileName": "marmu",
+      "displayName": "Marmu%"
+    },
+    {
+      "fileName": "max-0-geo",
+      "displayName": "Max% 0 Geo",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Max%25%200%20Geo.md"
+      }
+    },
+    {
+      "fileName": "mr-mushroom-ending",
+      "displayName": "Mr. Mushroom Ending",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Mr.%20Mushroom%20Ending.md"
+      }
+    },
+    {
+      "fileName": "myla",
+      "displayName": "Myla%",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Myla%25.md"
+      }
+    },
+    {
+      "fileName": "mylas-revenge",
+      "displayName": "Myla's Revenge",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Myla's%20Revenge.md"
+      }
+    },
+    {
+      "fileName": "nice",
+      "displayName": "Nice%",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Nice%25.md"
+      }
+    },
+    {
+      "fileName": "nice-1221",
+      "displayName": "Nice% (1.2.2.1)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Nice%25%20(1.2.2.1).md"
+      }
+    },
+    {
+      "fileName": "nkg",
+      "displayName": "NKG%",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/NKG%25.md"
+      }
+    },
+    {
+      "fileName": "nkg-nmms",
+      "displayName": "NKG% (No Main Menu Storage)",
+      "data": {}
+    },
+    {
+      "fileName": "nmg",
+      "displayName": "NMG%"
+    },
+    {
+      "fileName": "nosk",
+      "displayName": "Nosk%",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Nosk%25.md"
+      }
+    },
+    {
+      "fileName": "pop-percent",
+      "displayName": "Path of Pain%",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Path%20of%20Pain%25.md"
+      }
+    },
+    {
+      "fileName": "pure-snail",
+      "displayName": "Pure Snail",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Pure%20Snail.md"
+      }
+    },
+    {
+      "fileName": "p5bo",
+      "displayName": "Pantheon 5 Boss Order",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Pantheon%205%20Boss%20Order.md"
+      }
+    },
+    {
+      "fileName": "p5bo-breaks",
+      "displayName": "Pantheon 5 Boss Order (w/ breaks)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Pantheon%205%20Boss%20Order%20(w%EF%BC%8F%20breaks).md"
+      }
+    },
+    {
+      "fileName": "round",
+      "displayName": "Round%",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Round%25.md"
+      }
+    },
+    {
+      "fileName": "salubras-blessing",
+      "displayName": "Salubra's Blessing%",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Salubra's%20Blessing%25.md",
+        "searchTerms": [
+          "Smooch"
+        ]
+      }
+    },
+    {
+      "fileName": "sbaco",
+      "displayName": "Salubra's Blessing% ACO",
+      "data": {
+        "searchTerms": [
+          "Smooch",
+          "Alphabetical Charm Order"
+        ]
+      }
+    },
+    {
+      "fileName": "sbcmo",
+      "displayName": "Salubra's Blessing% CMO",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Salubra's%20Blessing%25%20CMO.md",
+        "searchTerms": [
+          "Smooch",
+          "Charm Menu Order"
+        ]
+      }
+    },
+    {
+      "fileName": "sbico",
+      "displayName": "Salubra's Blessing% ICO",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Salubra's%20Blessing%25%20ICO.md",
+        "searchTerms": [
+          "Smooch",
+          "Intended Charm Order"
+        ]
+      }
+    },
+    {
+      "fileName": "save-myla",
+      "displayName": "Save Myla (Dash Slash route)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Save%20Myla%20(Dash%20Slash%20route).md"
+      }
+    },
+    {
+      "fileName": "shriek",
+      "displayName": "Shriek%",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Shriek%25.md"
+      }
+    },
+    {
+      "fileName": "stinky",
+      "displayName": "Stinky% Comfy",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Stinky%25%20Comfy.md"
+      }
+    },
+    {
+      "fileName": "spelless",
+      "displayName": "Spelless",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Spelless.md"
+      }
+    },
+    {
+      "fileName": "spelless-dreamshield",
+      "displayName": "Spelless (Dreamshield)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Spelless%20(Dreamshield).md"
+      }
+    },
+    {
+      "fileName": "spelless-low",
+      "displayName": "Low% Spelless"
+    },
+    {
+      "fileName": "spelless-te",
+      "displayName": "Spelless True Ending",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Spelless%20True%20Ending.md"
+      }
+    },
+    {
+      "fileName": "spelless-te-dreamshield",
+      "displayName": "Spelless True Ending (Dreamshield)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Spelless%20True%20Ending%20(Dreamshield).md"
+      }
+    },
+    {
+      "fileName": "spinach",
+      "displayName": "SPINACH%",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/SPINACH%25.md"
+      }
+    },
+    {
+      "fileName": "who-ag",
+      "displayName": "Who% (All Glitches)"
+    },
+    {
+      "fileName": "who-nmms-1028",
+      "displayName": "Who% (No Main Menu Storage, 1028)"
+    },
+    {
+      "fileName": "who-nmms-itemless",
+      "displayName": "Who% (No Main Menu Storage, itemless stagclip)"
+    },
+    {
+      "fileName": "who-cdash",
+      "displayName": "Who% (Crystal Heart)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Who%25%20(Crystal%20Heart).md"
+      }
+    },
+    {
+      "fileName": "who-wings",
+      "displayName": "Who% (Monarch Wings)",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Who%25%20(Monarch%20Wings).md"
+      }
+    },
+    {
+      "fileName": "witness",
+      "displayName": "Witness",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Witness.md",
+        "searchTerms": [
+          "Quirrel"
+        ]
+      }
+    },
+    {
+      "fileName": "zote",
+      "displayName": "Zote%",
+      "data": {
+        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Zote%25.md"
+      }
+    }
+  ]
 }

--- a/src/asset/hollowknight/categories/category-directory.json
+++ b/src/asset/hollowknight/categories/category-directory.json
@@ -1,1086 +1,1086 @@
 {
-  "Main": [
-    {
-      "fileName": "106",
-      "displayName": "106% TE",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/106%25%20TE.md"
-      }
-    },
-    {
-      "fileName": "107-comsob",
-      "displayName": "107% AB (comsob splits)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/107%25%20AB%20(comsob%20splits).md"
-      }
-    },
-    {
-      "fileName": "107-everything",
-      "displayName": "107% AB (all splits)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/107%25%20AB%20(all%20splits).md"
-      }
-    },
-    {
-      "fileName": "112-comsob-late-fury",
-      "displayName": "112% APB (comsob splits)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/112%25%20APB%20(comsob%20splits).md"
-      }
-    },
-    {
-      "fileName": "112-everything-late-fury",
-      "displayName": "112% APB (all splits)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/112%25%20APB%20(all%20splits).md"
-      }
-    },
-    {
-      "fileName": "all-achievements",
-      "displayName": "All Achievements",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Achievements.md"
-      }
-    },
-    {
-      "fileName": "all-bosses-base-game",
-      "displayName": "All Bosses (Base Game)"
-    },
-    {
-      "fileName": "all-bosses-hidden-dreams",
-      "displayName": "All Bosses (Hidden Dreams)"
-    },
-    {
-      "fileName": "all-bosses-grimm-troupe",
-      "displayName": "All Bosses (Grimm Troupe)"
-    },
-    {
-      "fileName": "all-bosses-lifeblood",
-      "displayName": "All Bosses (Lifeblood)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Bosses%20(Lifeblood).md"
-      }
-    },
-    {
-      "fileName": "all-skills",
-      "displayName": "All Skills",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Skills.md"
-      }
-    },
-    {
-      "fileName": "all-skills-fury",
-      "displayName": "All Skills (1.2.2.1 Fury/iBaldur)"
-    },
-    {
-      "fileName": "all-skills-old-route",
-      "displayName": "All Skills (Old Route)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Skills%20(Old%20Route).md"
-      }
-    },
-    {
-      "fileName": "all-skills-1432plus",
-      "displayName": "All Skills (1.4.3.2+)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Skills%20(1.4.3.2%2B).md"
-      }
-    },
-    {
-      "fileName": "all-skills-emilitia",
-      "displayName": "All Skills (Emilitia)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Skills%20(Emilitia).md",
-        "searchTerms": [
-          "Eternal"
-        ]
-      }
-    },
-    {
-      "fileName": "any",
-      "displayName": "Any% (1.2.2.1)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Any%25%20(1.2.2.1).md"
-      }
-    },
-    {
-      "fileName": "any-shade-soul",
-      "displayName": "Any% (1.2.2.1 Shade Soul)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Any%25%20(1.2.2.1%20Shade%20Soul).md"
-      }
-    },
-    {
-      "fileName": "any-fury",
-      "displayName": "Any% (1.2.2.1 Fury/iBaldur)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Any%25%20(1.2.2.1%20Fury%EF%BC%8FiBaldur).md"
-      }
-    },
-    {
-      "fileName": "any-1432plus",
-      "displayName": "Any% (1.4.3.2+ QGA)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Any%25%20(1.4.3.2%2B%20QGA).md"
-      }
-    },
-    {
-      "fileName": "any-1432plus-shade-soul",
-      "displayName": "Any% (1.4.3.2+ Shade Soul)",
-      "data": {
-        "routeNotesURL": "https://www.speedrun.com/hollowknight/guide/p2d5f"
-      }
-    },
-    {
-      "fileName": "any-1432plus-spore",
-      "displayName": "Any% (1.4.3.2+ Spore Shroom/Deepnest)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Any%25%20(1.4.3.2%2B%20Spore%20Shroom%EF%BC%8FDeepnest).md"
-      }
-    },
-    {
-      "fileName": "any-1432plus-isma",
-      "displayName": "Any% (1.4.3.2+ Isma's Tear)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Any%25%20(1.4.3.2%2B%20Isma's%20Tear).md",
-        "searchTerms": [
-          "stallball",
-          "slopeball",
-          "magalore",
-          "mag isma"
-        ]
-      }
-    },
-    {
-      "fileName": "any-ss",
-      "displayName": "Any% Steel Soul",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Any%25%20Steel%20Soul.md"
-      }
-    },
-    {
-      "fileName": "any-blossom",
-      "displayName": "Any% (Blossom Edition)"
-    },
-    {
-      "fileName": "godhome-ending",
-      "displayName": "Godhome Ending"
-    },
-    {
-      "fileName": "low",
-      "displayName": "Low%",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Low%25.md"
-      }
-    },
-    {
-      "fileName": "low-1432plus",
-      "displayName": "Low% (1.4.3.2+)"
-    },
-    {
-      "fileName": "te",
-      "displayName": "True Ending",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/True%20Ending.md"
-      }
-    },
-    {
-      "fileName": "te-fury",
-      "displayName": "True Ending (1.2.2.1 Fury/iBaldur)"
-    },
-    {
-      "fileName": "te-1432plus",
-      "displayName": "True Ending (1.4.3.2+ SCSB)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/True%20Ending%20(1.4.3.2%2B%20SCSB).md",
-        "searchTerms": [
-          "soul catcher",
-          "steady body"
-        ]
-      }
-    },
-    {
-      "fileName": "te-flukamoth",
-      "displayName": "True Ending (\"Flukamoth\")"
-    }
-  ],
-  "Glitched": [
-    {
-      "fileName": "112-ag",
-      "displayName": "112% APB (All Glitches)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/112%25%20APB%20(All%20Glitches).md",
-        "searchTerms": [
-          "112",
-          "ag"
-        ]
-      }
-    },
-    {
-      "fileName": "all-skills-ag",
-      "displayName": "All Skills (All Glitches)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Skills%20(All%20Glitches).md",
-        "searchTerms": [
-          "ag"
-        ]
-      }
-    },
-    {
-      "fileName": "all-bosses-hidden-dreams-nmms",
-      "displayName": "All Bosses (Hidden Dreams, NMMS)"
-    },
-    {
-      "fileName": "all-bosses-grimm-troupe-nmms",
-      "displayName": "All Bosses (Grimm Troupe, NMMS)"
-    },
-    {
-      "fileName": "any-ag",
-      "displayName": "Any% (All Glitches)",
-      "data": {
-        "searchTerms": [
-          "ag"
-        ]
-      }
-    },
-    {
-      "fileName": "any-nmms",
-      "displayName": "Any% (No Main Menu Storage)",
-      "data": {
-        "searchTerms": [
-          "nmms"
-        ]
-      }
-    },
-    {
-      "fileName": "any-nmms-1028",
-      "displayName": "Any% (NMMS 1.0.2.8)",
-      "data": {
-        "searchTerms": [
-          "nmms"
-        ]
-      }
-    },
-    {
-      "fileName": "low-ag",
-      "displayName": "Low% (All Glitches)",
-      "data": {
-        "searchTerms": [
-          "low",
-          "ag"
-        ]
-      }
-    },
-    {
-      "fileName": "low-nmms",
-      "displayName": "Low% (No Main Menu Storage)",
-      "data": {
-        "searchTerms": [
-          "low",
-          "nmms"
-        ]
-      }
-    },
-    {
-      "fileName": "te-ag",
-      "displayName": "True Ending (All Glitches)",
-      "data": {
-        "searchTerms": [
-          "te",
-          "ag"
-        ]
-      }
-    },
-    {
-      "fileName": "te-ag-dupeless",
-      "displayName": "True Ending (All Glitches, Dupeless)",
-      "data": {
-        "searchTerms": [
-          "te",
-          "ag"
-        ]
-      }
-    },
-    {
-      "fileName": "te-nmms",
-      "displayName": "True Ending (No Main Menu Storage)",
-      "data": {
-        "searchTerms": [
-          "te",
-          "nmms"
-        ]
-      }
-    }
-  ],
-  "Individual Level": [
-    {
-      "fileName": "colo1",
-      "displayName": "Trial of the Warrior (colo1)"
-    },
-    {
-      "fileName": "colo1-waves",
-      "displayName": "Colo 1 w/ Autosplit Waves"
-    },
-    {
-      "fileName": "colo2",
-      "displayName": "Trial of the Conqueror (colo2)"
-    },
-    {
-      "fileName": "colo2-waves",
-      "displayName": "Colo 2 w/ Autosplit Waves"
-    },
-    {
-      "fileName": "colo3",
-      "displayName": "Trial of the Fool (colo3)"
-    },
-    {
-      "fileName": "colo3-waves",
-      "displayName": "Colo 3 w/ Autosplit Waves"
-    },
-    {
-      "fileName": "kp",
-      "displayName": "King's Pass"
-    },
-    {
-      "fileName": "menderbug",
-      "displayName": "Menderbug%"
-    },
-    {
-      "fileName": "p1",
-      "displayName": "Pantheon of the Master (P1)"
-    },
-    {
-      "fileName": "p2",
-      "displayName": "Pantheon of the Artist (P2)"
-    },
-    {
-      "fileName": "p3",
-      "displayName": "Pantheon of the Sage (P3)"
-    },
-    {
-      "fileName": "p4",
-      "displayName": "Pantheon of the Knight (P4)"
-    },
-    {
-      "fileName": "p5",
-      "displayName": "Pantheon of Hallownest (P5)"
-    },
-    {
-      "fileName": "pop",
-      "displayName": "Path of Pain"
-    },
-    {
-      "fileName": "wp",
-      "displayName": "White Palace"
-    },
-    {
-      "fileName": "wp-1315plus",
-      "displayName": "White Palace IL (1.3.1.5+)"
-    },
-    {
-      "fileName": "room-timer",
-      "displayName": "Room Timer",
-      "data": {
-        "searchTerms": [
-          "Abyss Climb"
-        ]
-      }
-    }
-  ],
-  "Mods": [
-    {
-      "fileName": "all-geo-rocks",
-      "displayName": "All Geo Rocks",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Geo%20Rocks.md"
-      }
-    },
-    {
-      "fileName": "fc-as-te",
-      "displayName": "Forgotten Corners AS TE",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Forgotten%20Corners%20AS%20TE.md"
-      }
-    },
-    {
-      "fileName": "grass",
-      "displayName": "Grass%",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Grass%25.md"
-      }
-    },
-    {
-      "fileName": "kronk",
-      "displayName": "Kronk%",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Kronk%25.md"
-      }
-    },
-    {
-      "fileName": "myla-flower",
-      "displayName": "Myla Flower",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Myla%20Flower.md"
-      }
-    },
-    {
-      "fileName": "low-ab",
-      "displayName": "Low% All Bindings",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Low%25%20All%20Bindings.md"
-      }
-    },
-    {
-      "fileName": "rando-te",
-      "displayName": "Randomizer TE (add splits as desired)"
-    }
-  ],
-  "Category Extensions": [
-    {
-      "fileName": "0geo",
-      "displayName": "0 Geo",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/0%20Geo.md"
-      }
-    },
-    {
-      "fileName": "3vf-kings-station",
-      "displayName": "3 Vessel Fragments (King's Station)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/3%20Vessel%20Fragments%20(King's%20Station).md"
-      }
-    },
-    {
-      "fileName": "3vf-stag-nest",
-      "displayName": "3 Vessel Fragments (Stag Nest)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/3%20Vessel%20Fragments%20(Stag%20Nest).md"
-      }
-    },
-    {
-      "fileName": "worldsoul",
-      "displayName": "Worldsoul (9 Vessel Fragments)"
-    },
-    {
-      "fileName": "4ms",
-      "displayName": "4 Mask Shards",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/4%20Mask%20Shards.md"
-      }
-    },
-    {
-      "fileName": "4ms-0geo",
-      "displayName": "4 Mask Shards 0 Geo",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/4%20Mask%20Shards%200%20Geo.md"
-      }
-    },
-    {
-      "fileName": "8ms",
-      "displayName": "8 Mask Shards",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/8%20Mask%20Shards.md"
-      }
-    },
-    {
-      "fileName": "8ms-fc-stag",
-      "displayName": "8 Mask Shards (FC Stag Route)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/8%20Mask%20Shards%20(FC%20Stag%20Route).md"
-      }
-    },
-    {
-      "fileName": "12ms",
-      "displayName": "12 Mask Shards",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/12%20Mask%20Shards.md"
-      }
-    },
-    {
-      "fileName": "16ms",
-      "displayName": "16 Mask Shards",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/16%20Mask%20Shards.md",
-        "searchTerms": [
-          "All",
-          "Skulls"
-        ]
-      }
-    },
-    {
-      "fileName": "5-mimics",
-      "displayName": "5 Mimics",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/5%20Mimics.md"
-      }
-    },
-    {
-      "fileName": "100-completion",
-      "displayName": "100% Completion",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/100%25%20Completion.md"
-      }
-    },
-    {
-      "fileName": "agag",
-      "displayName": "All Grubs All Glitches",
-      "data": {
-        "searchTerms": [
-          "ag",
-          "agag",
-          "elegy"
-        ],
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Grubs%20All%20Glitches.md"
-      }
-    },
-    {
-      "fileName": "all-broken-charms",
-      "displayName": "All Broken Charms",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Broken%20Charms.md"
-      }
-    },
-    {
-      "fileName": "all-dream-bosses-1432plus",
-      "displayName": "All Dream Bosses (1.4.3.2+, flukes)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Dream%20Bosses%20(1.4.3.2%2B%2C%20flukes).md"
-      }
-    },
-    {
-      "fileName": "acn",
-      "displayName": "All Charm Notches",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Charm%20Notches.md"
-      }
-    },
-    {
-      "fileName": "acn-1221",
-      "displayName": "All Charm Notches (1.2.2.1)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Charm%20Notches%20(1.2.2.1).md"
-      }
-    },
-    {
-      "fileName": "acnnsc",
-      "displayName": "ACN No Shop Charms",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/ACN%20No%20Shop%20Charms.md",
-        "searchTerms": [
-          "All",
-          "Notches"
-        ]
-      }
-    },
-    {
-      "fileName": "acnkgpz",
-      "displayName": "ACNKGPZ%",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/ACNKGPZ%25.md"
-      }
-    },
-    {
-      "fileName": "all-geo-chests",
-      "displayName": "All Geo Chests",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Geo%20Chests.md"
-      }
-    },
-    {
-      "fileName": "all-hallownest-seals",
-      "displayName": "All Hallownest Seals",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Hallownest%20Seals.md"
-      }
-    },
-    {
-      "fileName": "all-keys",
-      "displayName": "All Keys",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Keys.md"
-      }
-    },
-    {
-      "fileName": "all-kings-idols",
-      "displayName": "All King's Idols",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20King's%20Idols.md"
-      }
-    },
-    {
-      "fileName": "all-stag-stations",
-      "displayName": "All Stag Stations",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Stag%20Stations.md"
-      }
-    },
-    {
-      "fileName": "all-unbreakable-charms",
-      "displayName": "All Unbreakable Charms"
-    },
-    {
-      "fileName": "all-unbreakable-charms-ss",
-      "displayName": "All Unbreakable Charms (Steel Soul)"
-    },
-    {
-      "fileName": "all-wanderers-journals",
-      "displayName": "All Wanderer's Journals",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Wanderer's%20Journals.md"
-      }
-    },
-    {
-      "fileName": "all-whispering-roots",
-      "displayName": "All Whispering Roots",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Whispering%20Roots.md"
-      }
-    },
-    {
-      "fileName": "a1uba",
-      "displayName": "A1uba%",
-      "data": {
-        "searchTerms": [
-          "Aluba"
-        ]
-      }
-    },
-    {
-      "fileName": "al2ba",
-      "displayName": "Al2ba%",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Al2ba%25.md",
-        "searchTerms": [
-          "Aluba"
-        ]
-      }
-    },
-    {
-      "fileName": "cartographer",
-      "displayName": "Cartographer",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Cartographer.md",
-        "searchTerms": [
-          "Dapper",
-          "Mapper",
-          "all",
-          "maps",
-          "Cornifer",
-          "Iselda"
-        ]
-      }
-    },
-    {
-      "fileName": "clawless-shade-cloak",
-      "displayName": "Clawless Shade Cloak (CSC)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Clawless%20Shade%20Cloak%20(CSC).md"
-      }
-    },
-    {
-      "fileName": "eat-me-too",
-      "displayName": "Eat Me Too"
-    },
-    {
-      "fileName": "elderbug",
-      "displayName": "Elderbug%",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Elderbug%25.md",
-        "searchTerms": [
-          "Delicate",
-          "Flower"
-        ]
-      }
-    },
-    {
-      "fileName": "elegy",
-      "displayName": "Elegy%",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Elegy%25.md"
-      }
-    },
-    {
-      "fileName": "empty-hall",
-      "displayName": "Empty Hall",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Empty%20Hall.md",
-        "searchTerms": [
-          "Godhome",
-          "Gods"
-        ]
-      }
-    },
-    {
-      "fileName": "egg",
-      "displayName": "Egg (21)"
-    },
-    {
-      "fileName": "egg-101",
-      "displayName": "Egg (101)"
-    },
-    {
-      "fileName": "enraged-guardian",
-      "displayName": "Enraged Guardian%"
-    },
-    {
-      "fileName": "eternal-ordeal-1mg",
-      "displayName": "Eternal Ordeal% 1mg",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Eternal%20Ordeal%25%201mg.md",
-        "searchTerms": [
-          "Zote"
-        ]
-      }
-    },
-    {
-      "fileName": "fool-1221",
-      "displayName": "Fool% (1.2.2.1)",
-      "data": {
-        "routeNotesURL": "https://youtu.be/dQw4w9WgXcQ"
-      }
-    },
-    {
-      "fileName": "ggg",
-      "displayName": "Gaslight, Gatekeep, Girlboss",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Gaslight%2C%20Gatekeep%2C%20Girlboss.md",
-        "searchTerms": [
-          "City Crest",
-          "Nightmare Lantern",
-          "Eternal Emilitia"
-        ]
-      }
-    },
-    {
-      "fileName": "grubsong",
-      "displayName": "Grubsong%",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Grubsong%25.md"
-      }
-    },
-    {
-      "fileName": "florist",
-      "displayName": "Florist",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Florist.md",
-        "searchTerms": [
-          "Delicate",
-          "Flower"
-        ]
-      }
-    },
-    {
-      "fileName": "ghostbusters",
-      "displayName": "Ghostbusters",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Ghostbusters.md"
-      }
-    },
-    {
-      "fileName": "gpz",
-      "displayName": "GPZ%",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/GPZ%25.md",
-        "searchTerms": [
-          "Zote"
-        ]
-      }
-    },
-    {
-      "fileName": "great-hopper",
-      "displayName": "Great Hopper%",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Great%20Hopper%25.md"
-      }
-    },
-    {
-      "fileName": "godhome",
-      "displayName": "Godhome (Godseeker mode)"
-    },
-    {
-      "fileName": "happy-couple",
-      "displayName": "Happy Couple",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Happy%20Couple.md"
-      }
-    },
-    {
-      "fileName": "happy-couple-1221",
-      "displayName": "Happy Couple (1.2.2.1)"
-    },
-    {
-      "fileName": "hiveblood",
-      "displayName": "Hiveblood%",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Hiveblood%25.md"
-      }
-    },
-    {
-      "fileName": "lbc",
-      "displayName": "Lifeblood Core%"
-    },
-    {
-      "fileName": "low-te-dropless",
-      "displayName": "Low% True Ending Dropless",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Low%25%20True%20Ending%20Dropless.md"
-      }
-    },
-    {
-      "fileName": "marissa-audience",
-      "displayName": "Marissa Audience",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Marissa%20Audience.md"
-      }
-    },
-    {
-      "fileName": "marmu",
-      "displayName": "Marmu%"
-    },
-    {
-      "fileName": "max-0-geo",
-      "displayName": "Max% 0 Geo",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Max%25%200%20Geo.md"
-      }
-    },
-    {
-      "fileName": "mr-mushroom-ending",
-      "displayName": "Mr. Mushroom Ending",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Mr.%20Mushroom%20Ending.md"
-      }
-    },
-    {
-      "fileName": "myla",
-      "displayName": "Myla%",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Myla%25.md"
-      }
-    },
-    {
-      "fileName": "mylas-revenge",
-      "displayName": "Myla's Revenge",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Myla's%20Revenge.md"
-      }
-    },
-    {
-      "fileName": "nice",
-      "displayName": "Nice%",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Nice%25.md"
-      }
-    },
-    {
-      "fileName": "nice-1221",
-      "displayName": "Nice% (1.2.2.1)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Nice%25%20(1.2.2.1).md"
-      }
-    },
-    {
-      "fileName": "nkg",
-      "displayName": "NKG%",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/NKG%25.md"
-      }
-    },
-    {
-      "fileName": "nkg-nmms",
-      "displayName": "NKG% (No Main Menu Storage)",
-      "data": {}
-    },
-    {
-      "fileName": "nmg",
-      "displayName": "NMG%"
-    },
-    {
-      "fileName": "nosk",
-      "displayName": "Nosk%",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Nosk%25.md"
-      }
-    },
-    {
-      "fileName": "pop-percent",
-      "displayName": "Path of Pain%",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Path%20of%20Pain%25.md"
-      }
-    },
-    {
-      "fileName": "pure-snail",
-      "displayName": "Pure Snail",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Pure%20Snail.md"
-      }
-    },
-    {
-      "fileName": "p5bo",
-      "displayName": "Pantheon 5 Boss Order",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Pantheon%205%20Boss%20Order.md"
-      }
-    },
-    {
-      "fileName": "p5bo-breaks",
-      "displayName": "Pantheon 5 Boss Order (w/ breaks)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Pantheon%205%20Boss%20Order%20(w%EF%BC%8F%20breaks).md"
-      }
-    },
-    {
-      "fileName": "round",
-      "displayName": "Round%",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Round%25.md"
-      }
-    },
-    {
-      "fileName": "salubras-blessing",
-      "displayName": "Salubra's Blessing%",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Salubra's%20Blessing%25.md",
-        "searchTerms": [
-          "Smooch"
-        ]
-      }
-    },
-    {
-      "fileName": "sbaco",
-      "displayName": "Salubra's Blessing% ACO",
-      "data": {
-        "searchTerms": [
-          "Smooch",
-          "Alphabetical Charm Order"
-        ]
-      }
-    },
-    {
-      "fileName": "sbcmo",
-      "displayName": "Salubra's Blessing% CMO",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Salubra's%20Blessing%25%20CMO.md",
-        "searchTerms": [
-          "Smooch",
-          "Charm Menu Order"
-        ]
-      }
-    },
-    {
-      "fileName": "sbico",
-      "displayName": "Salubra's Blessing% ICO",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Salubra's%20Blessing%25%20ICO.md",
-        "searchTerms": [
-          "Smooch",
-          "Intended Charm Order"
-        ]
-      }
-    },
-    {
-      "fileName": "save-myla",
-      "displayName": "Save Myla (Dash Slash route)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Save%20Myla%20(Dash%20Slash%20route).md"
-      }
-    },
-    {
-      "fileName": "shriek",
-      "displayName": "Shriek%",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Shriek%25.md"
-      }
-    },
-    {
-      "fileName": "stinky",
-      "displayName": "Stinky% Comfy",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Stinky%25%20Comfy.md"
-      }
-    },
-    {
-      "fileName": "spelless",
-      "displayName": "Spelless",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Spelless.md"
-      }
-    },
-    {
-      "fileName": "spelless-dreamshield",
-      "displayName": "Spelless (Dreamshield)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Spelless%20(Dreamshield).md"
-      }
-    },
-    {
-      "fileName": "spelless-low",
-      "displayName": "Low% Spelless"
-    },
-    {
-      "fileName": "spelless-te",
-      "displayName": "Spelless True Ending",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Spelless%20True%20Ending.md"
-      }
-    },
-    {
-      "fileName": "spelless-te-dreamshield",
-      "displayName": "Spelless True Ending (Dreamshield)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Spelless%20True%20Ending%20(Dreamshield).md"
-      }
-    },
-    {
-      "fileName": "spinach",
-      "displayName": "SPINACH%",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/SPINACH%25.md"
-      }
-    },
-    {
-      "fileName": "who-ag",
-      "displayName": "Who% (All Glitches)"
-    },
-    {
-      "fileName": "who-nmms-1028",
-      "displayName": "Who% (No Main Menu Storage, 1028)"
-    },
-    {
-      "fileName": "who-nmms-itemless",
-      "displayName": "Who% (No Main Menu Storage, itemless stagclip)"
-    },
-    {
-      "fileName": "who-cdash",
-      "displayName": "Who% (Crystal Heart)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Who%25%20(Crystal%20Heart).md"
-      }
-    },
-    {
-      "fileName": "who-wings",
-      "displayName": "Who% (Monarch Wings)",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Who%25%20(Monarch%20Wings).md"
-      }
-    },
-    {
-      "fileName": "witness",
-      "displayName": "Witness",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Witness.md",
-        "searchTerms": [
-          "Quirrel"
-        ]
-      }
-    },
-    {
-      "fileName": "zote",
-      "displayName": "Zote%",
-      "data": {
-        "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Zote%25.md"
-      }
-    }
-  ]
+    "Main": [
+        {
+            "fileName": "106",
+            "displayName": "106% TE",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/106%25%20TE.md"
+            }
+        },
+        {
+            "fileName": "107-comsob",
+            "displayName": "107% AB (comsob splits)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/107%25%20AB%20(comsob%20splits).md"
+            }
+        },
+        {
+            "fileName": "107-everything",
+            "displayName": "107% AB (all splits)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/107%25%20AB%20(all%20splits).md"
+            }
+        },
+        {
+            "fileName": "112-comsob-late-fury",
+            "displayName": "112% APB (comsob splits)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/112%25%20APB%20(comsob%20splits).md"
+            }
+        },
+        {
+            "fileName": "112-everything-late-fury",
+            "displayName": "112% APB (all splits)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/112%25%20APB%20(all%20splits).md"
+            }
+        },
+        {
+            "fileName": "all-achievements",
+            "displayName": "All Achievements",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Achievements.md"
+            }
+        },
+        {
+            "fileName": "all-bosses-base-game",
+            "displayName": "All Bosses (Base Game)"
+        },
+        {
+            "fileName": "all-bosses-hidden-dreams",
+            "displayName": "All Bosses (Hidden Dreams)"
+        },
+        {
+            "fileName": "all-bosses-grimm-troupe",
+            "displayName": "All Bosses (Grimm Troupe)"
+        },
+        {
+            "fileName": "all-bosses-lifeblood",
+            "displayName": "All Bosses (Lifeblood)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Bosses%20(Lifeblood).md"
+            }
+        },
+        {
+            "fileName": "all-skills",
+            "displayName": "All Skills",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Skills.md"
+            }
+        },
+        {
+            "fileName": "all-skills-fury",
+            "displayName": "All Skills (1.2.2.1 Fury/iBaldur)"
+        },
+        {
+            "fileName": "all-skills-old-route",
+            "displayName": "All Skills (Old Route)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Skills%20(Old%20Route).md"
+            }
+        },
+        {
+            "fileName": "all-skills-1432plus",
+            "displayName": "All Skills (1.4.3.2+)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Skills%20(1.4.3.2%2B).md"
+            }
+        },
+        {
+            "fileName": "all-skills-emilitia",
+            "displayName": "All Skills (Emilitia)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Skills%20(Emilitia).md",
+                "searchTerms": [
+                    "Eternal"
+                ]
+            }
+        },
+        {
+            "fileName": "any",
+            "displayName": "Any% (1.2.2.1)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Any%25%20(1.2.2.1).md"
+            }
+        },
+        {
+            "fileName": "any-shade-soul",
+            "displayName": "Any% (1.2.2.1 Shade Soul)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Any%25%20(1.2.2.1%20Shade%20Soul).md"
+            }
+        },
+        {
+            "fileName": "any-fury",
+            "displayName": "Any% (1.2.2.1 Fury/iBaldur)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Any%25%20(1.2.2.1%20Fury%EF%BC%8FiBaldur).md"
+            }
+        },
+        {
+            "fileName": "any-1432plus",
+            "displayName": "Any% (1.4.3.2+ QGA)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Any%25%20(1.4.3.2%2B%20QGA).md"
+            }
+        },
+        {
+            "fileName": "any-1432plus-shade-soul",
+            "displayName": "Any% (1.4.3.2+ Shade Soul)",
+            "data": {
+                "routeNotesURL": "https://www.speedrun.com/hollowknight/guide/p2d5f"
+            }
+        },
+        {
+            "fileName": "any-1432plus-spore",
+            "displayName": "Any% (1.4.3.2+ Spore Shroom/Deepnest)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Any%25%20(1.4.3.2%2B%20Spore%20Shroom%EF%BC%8FDeepnest).md"
+            }
+        },
+        {
+            "fileName": "any-1432plus-isma",
+            "displayName": "Any% (1.4.3.2+ Isma's Tear)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Any%25%20(1.4.3.2%2B%20Isma's%20Tear).md",
+                "searchTerms": [
+                    "stallball",
+                    "slopeball",
+                    "magalore",
+                    "mag isma"
+                ]
+            }
+        },
+        {
+            "fileName": "any-ss",
+            "displayName": "Any% Steel Soul",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Any%25%20Steel%20Soul.md"
+            }
+        },
+        {
+            "fileName": "any-blossom",
+            "displayName": "Any% (Blossom Edition)"
+        },
+        {
+            "fileName": "godhome-ending",
+            "displayName": "Godhome Ending"
+        },
+        {
+            "fileName": "low",
+            "displayName": "Low%",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Low%25.md"
+            }
+        },
+        {
+            "fileName": "low-1432plus",
+            "displayName": "Low% (1.4.3.2+)"
+        },
+        {
+            "fileName": "te",
+            "displayName": "True Ending",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/True%20Ending.md"
+            }
+        },
+        {
+            "fileName": "te-fury",
+            "displayName": "True Ending (1.2.2.1 Fury/iBaldur)"
+        },
+        {
+            "fileName": "te-1432plus",
+            "displayName": "True Ending (1.4.3.2+ SCSB)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/True%20Ending%20(1.4.3.2%2B%20SCSB).md",
+                "searchTerms": [
+                    "soul catcher",
+                    "steady body"
+                ]
+            }
+        },
+        {
+            "fileName": "te-flukamoth",
+            "displayName": "True Ending (\"Flukamoth\")"
+        }
+    ],
+    "Glitched": [
+        {
+            "fileName": "112-ag",
+            "displayName": "112% APB (All Glitches)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/112%25%20APB%20(All%20Glitches).md",
+                "searchTerms": [
+                    "112",
+                    "ag"
+                ]
+            }
+        },
+        {
+            "fileName": "all-skills-ag",
+            "displayName": "All Skills (All Glitches)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Skills%20(All%20Glitches).md",
+                "searchTerms": [
+                    "ag"
+                ]
+            }
+        },
+        {
+            "fileName": "all-bosses-hidden-dreams-nmms",
+            "displayName": "All Bosses (Hidden Dreams, NMMS)"
+        },
+        {
+            "fileName": "all-bosses-grimm-troupe-nmms",
+            "displayName": "All Bosses (Grimm Troupe, NMMS)"
+        },
+        {
+            "fileName": "any-ag",
+            "displayName": "Any% (All Glitches)",
+            "data": {
+                "searchTerms": [
+                    "ag"
+                ]
+            }
+        },
+        {
+            "fileName": "any-nmms",
+            "displayName": "Any% (No Main Menu Storage)",
+            "data": {
+                "searchTerms": [
+                    "nmms"
+                ]
+            }
+        },
+        {
+            "fileName": "any-nmms-1028",
+            "displayName": "Any% (NMMS 1.0.2.8)",
+            "data": {
+                "searchTerms": [
+                    "nmms"
+                ]
+            }
+        },
+        {
+            "fileName": "low-ag",
+            "displayName": "Low% (All Glitches)",
+            "data": {
+                "searchTerms": [
+                    "low",
+                    "ag"
+                ]
+            }
+        },
+        {
+            "fileName": "low-nmms",
+            "displayName": "Low% (No Main Menu Storage)",
+            "data": {
+                "searchTerms": [
+                    "low",
+                    "nmms"
+                ]
+            }
+        },
+        {
+            "fileName": "te-ag",
+            "displayName": "True Ending (All Glitches)",
+            "data": {
+                "searchTerms": [
+                    "te",
+                    "ag"
+                ]
+            }
+        },
+        {
+            "fileName": "te-ag-dupeless",
+            "displayName": "True Ending (All Glitches, Dupeless)",
+            "data": {
+                "searchTerms": [
+                    "te",
+                    "ag"
+                ]
+            }
+        },
+        {
+            "fileName": "te-nmms",
+            "displayName": "True Ending (No Main Menu Storage)",
+            "data": {
+                "searchTerms": [
+                    "te",
+                    "nmms"
+                ]
+            }
+        }
+    ],
+    "Individual Level": [
+        {
+            "fileName": "colo1",
+            "displayName": "Trial of the Warrior (colo1)"
+        },
+        {
+            "fileName": "colo1-waves",
+            "displayName": "Colo 1 w/ Autosplit Waves"
+        },
+        {
+            "fileName": "colo2",
+            "displayName": "Trial of the Conqueror (colo2)"
+        },
+        {
+            "fileName": "colo2-waves",
+            "displayName": "Colo 2 w/ Autosplit Waves"
+        },
+        {
+            "fileName": "colo3",
+            "displayName": "Trial of the Fool (colo3)"
+        },
+        {
+            "fileName": "colo3-waves",
+            "displayName": "Colo 3 w/ Autosplit Waves"
+        },
+        {
+            "fileName": "kp",
+            "displayName": "King's Pass"
+        },
+        {
+            "fileName": "menderbug",
+            "displayName": "Menderbug%"
+        },
+        {
+            "fileName": "p1",
+            "displayName": "Pantheon of the Master (P1)"
+        },
+        {
+            "fileName": "p2",
+            "displayName": "Pantheon of the Artist (P2)"
+        },
+        {
+            "fileName": "p3",
+            "displayName": "Pantheon of the Sage (P3)"
+        },
+        {
+            "fileName": "p4",
+            "displayName": "Pantheon of the Knight (P4)"
+        },
+        {
+            "fileName": "p5",
+            "displayName": "Pantheon of Hallownest (P5)"
+        },
+        {
+            "fileName": "pop",
+            "displayName": "Path of Pain"
+        },
+        {
+            "fileName": "wp",
+            "displayName": "White Palace"
+        },
+        {
+            "fileName": "wp-1315plus",
+            "displayName": "White Palace IL (1.3.1.5+)"
+        },
+        {
+            "fileName": "room-timer",
+            "displayName": "Room Timer",
+            "data": {
+                "searchTerms": [
+                    "Abyss Climb"
+                ]
+            }
+        }
+    ],
+    "Mods": [
+        {
+            "fileName": "all-geo-rocks",
+            "displayName": "All Geo Rocks",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Geo%20Rocks.md"
+            }
+        },
+        {
+            "fileName": "fc-as-te",
+            "displayName": "Forgotten Corners AS TE",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Forgotten%20Corners%20AS%20TE.md"
+            }
+        },
+        {
+            "fileName": "grass",
+            "displayName": "Grass%",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Grass%25.md"
+            }
+        },
+        {
+            "fileName": "kronk",
+            "displayName": "Kronk%",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Kronk%25.md"
+            }
+        },
+        {
+            "fileName": "myla-flower",
+            "displayName": "Myla Flower",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Myla%20Flower.md"
+            }
+        },
+        {
+            "fileName": "low-ab",
+            "displayName": "Low% All Bindings",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Low%25%20All%20Bindings.md"
+            }
+        },
+        {
+            "fileName": "rando-te",
+            "displayName": "Randomizer TE (add splits as desired)"
+        }
+    ],
+    "Category Extensions": [
+        {
+            "fileName": "0geo",
+            "displayName": "0 Geo",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/0%20Geo.md"
+            }
+        },
+        {
+            "fileName": "3vf-kings-station",
+            "displayName": "3 Vessel Fragments (King's Station)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/3%20Vessel%20Fragments%20(King's%20Station).md"
+            }
+        },
+        {
+            "fileName": "3vf-stag-nest",
+            "displayName": "3 Vessel Fragments (Stag Nest)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/3%20Vessel%20Fragments%20(Stag%20Nest).md"
+            }
+        },
+        {
+            "fileName": "worldsoul",
+            "displayName": "Worldsoul (9 Vessel Fragments)"
+        },
+        {
+            "fileName": "4ms",
+            "displayName": "4 Mask Shards",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/4%20Mask%20Shards.md"
+            }
+        },
+        {
+            "fileName": "4ms-0geo",
+            "displayName": "4 Mask Shards 0 Geo",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/4%20Mask%20Shards%200%20Geo.md"
+            }
+        },
+        {
+            "fileName": "8ms",
+            "displayName": "8 Mask Shards",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/8%20Mask%20Shards.md"
+            }
+        },
+        {
+            "fileName": "8ms-fc-stag",
+            "displayName": "8 Mask Shards (FC Stag Route)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/8%20Mask%20Shards%20(FC%20Stag%20Route).md"
+            }
+        },
+        {
+            "fileName": "12ms",
+            "displayName": "12 Mask Shards",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/12%20Mask%20Shards.md"
+            }
+        },
+        {
+            "fileName": "16ms",
+            "displayName": "16 Mask Shards",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/16%20Mask%20Shards.md",
+                "searchTerms": [
+                    "All",
+                    "Skulls"
+                ]
+            }
+        },
+        {
+            "fileName": "5-mimics",
+            "displayName": "5 Mimics",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/5%20Mimics.md"
+            }
+        },
+        {
+            "fileName": "100-completion",
+            "displayName": "100% Completion",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/100%25%20Completion.md"
+            }
+        },
+        {
+            "fileName": "agag",
+            "displayName": "All Grubs All Glitches",
+            "data": {
+                "searchTerms": [
+                    "ag",
+                    "agag",
+                    "elegy"
+                ],
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Grubs%20All%20Glitches.md"
+            }
+        },
+        {
+            "fileName": "all-broken-charms",
+            "displayName": "All Broken Charms",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Broken%20Charms.md"
+            }
+        },
+        {
+            "fileName": "all-dream-bosses-1432plus",
+            "displayName": "All Dream Bosses (1.4.3.2+, flukes)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Dream%20Bosses%20(1.4.3.2%2B%2C%20flukes).md"
+            }
+        },
+        {
+            "fileName": "acn",
+            "displayName": "All Charm Notches",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Charm%20Notches.md"
+            }
+        },
+        {
+            "fileName": "acn-1221",
+            "displayName": "All Charm Notches (1.2.2.1)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Charm%20Notches%20(1.2.2.1).md"
+            }
+        },
+        {
+            "fileName": "acnnsc",
+            "displayName": "ACN No Shop Charms",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/ACN%20No%20Shop%20Charms.md",
+                "searchTerms": [
+                    "All",
+                    "Notches"
+                ]
+            }
+        },
+        {
+            "fileName": "acnkgpz",
+            "displayName": "ACNKGPZ%",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/ACNKGPZ%25.md"
+            }
+        },
+        {
+            "fileName": "all-geo-chests",
+            "displayName": "All Geo Chests",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Geo%20Chests.md"
+            }
+        },
+        {
+            "fileName": "all-hallownest-seals",
+            "displayName": "All Hallownest Seals",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Hallownest%20Seals.md"
+            }
+        },
+        {
+            "fileName": "all-keys",
+            "displayName": "All Keys",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Keys.md"
+            }
+        },
+        {
+            "fileName": "all-kings-idols",
+            "displayName": "All King's Idols",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20King's%20Idols.md"
+            }
+        },
+        {
+            "fileName": "all-stag-stations",
+            "displayName": "All Stag Stations",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Stag%20Stations.md"
+            }
+        },
+        {
+            "fileName": "all-unbreakable-charms",
+            "displayName": "All Unbreakable Charms"
+        },
+        {
+            "fileName": "all-unbreakable-charms-ss",
+            "displayName": "All Unbreakable Charms (Steel Soul)"
+        },
+        {
+            "fileName": "all-wanderers-journals",
+            "displayName": "All Wanderer's Journals",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Wanderer's%20Journals.md"
+            }
+        },
+        {
+            "fileName": "all-whispering-roots",
+            "displayName": "All Whispering Roots",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/All%20Whispering%20Roots.md"
+            }
+        },
+        {
+            "fileName": "a1uba",
+            "displayName": "A1uba%",
+            "data": {
+                "searchTerms": [
+                    "Aluba"
+                ]
+            }
+        },
+        {
+            "fileName": "al2ba",
+            "displayName": "Al2ba%",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Al2ba%25.md",
+                "searchTerms": [
+                    "Aluba"
+                ]
+            }
+        },
+        {
+            "fileName": "cartographer",
+            "displayName": "Cartographer",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Cartographer.md",
+                "searchTerms": [
+                    "Dapper",
+                    "Mapper",
+                    "all",
+                    "maps",
+                    "Cornifer",
+                    "Iselda"
+                ]
+            }
+        },
+        {
+            "fileName": "clawless-shade-cloak",
+            "displayName": "Clawless Shade Cloak (CSC)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Clawless%20Shade%20Cloak%20(CSC).md"
+            }
+        },
+        {
+            "fileName": "eat-me-too",
+            "displayName": "Eat Me Too"
+        },
+        {
+            "fileName": "elderbug",
+            "displayName": "Elderbug%",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Elderbug%25.md",
+                "searchTerms": [
+                    "Delicate",
+                    "Flower"
+                ]
+            }
+        },
+        {
+            "fileName": "elegy",
+            "displayName": "Elegy%",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Elegy%25.md"
+            }
+        },
+        {
+            "fileName": "empty-hall",
+            "displayName": "Empty Hall",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Empty%20Hall.md",
+                "searchTerms": [
+                    "Godhome",
+                    "Gods"
+                ]
+            }
+        },
+        {
+            "fileName": "egg",
+            "displayName": "Egg (21)"
+        },
+        {
+            "fileName": "egg-101",
+            "displayName": "Egg (101)"
+        },
+        {
+            "fileName": "enraged-guardian",
+            "displayName": "Enraged Guardian%"
+        },
+        {
+            "fileName": "eternal-ordeal-1mg",
+            "displayName": "Eternal Ordeal% 1mg",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Eternal%20Ordeal%25%201mg.md",
+                "searchTerms": [
+                    "Zote"
+                ]
+            }
+        },
+        {
+            "fileName": "fool-1221",
+            "displayName": "Fool% (1.2.2.1)",
+            "data": {
+                "routeNotesURL": "https://youtu.be/dQw4w9WgXcQ"
+            }
+        },
+        {
+            "fileName": "ggg",
+            "displayName": "Gaslight, Gatekeep, Girlboss",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Gaslight%2C%20Gatekeep%2C%20Girlboss.md",
+                "searchTerms": [
+                    "City Crest",
+                    "Nightmare Lantern",
+                    "Eternal Emilitia"
+                ]
+            }
+        },
+        {
+            "fileName": "grubsong",
+            "displayName": "Grubsong%",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Grubsong%25.md"
+            }
+        },
+        {
+            "fileName": "florist",
+            "displayName": "Florist",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Florist.md",
+                "searchTerms": [
+                    "Delicate",
+                    "Flower"
+                ]
+            }
+        },
+        {
+            "fileName": "ghostbusters",
+            "displayName": "Ghostbusters",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Ghostbusters.md"
+            }
+        },
+        {
+            "fileName": "gpz",
+            "displayName": "GPZ%",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/GPZ%25.md",
+                "searchTerms": [
+                    "Zote"
+                ]
+            }
+        },
+        {
+            "fileName": "great-hopper",
+            "displayName": "Great Hopper%",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Great%20Hopper%25.md"
+            }
+        },
+        {
+            "fileName": "godhome",
+            "displayName": "Godhome (Godseeker mode)"
+        },
+        {
+            "fileName": "happy-couple",
+            "displayName": "Happy Couple",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Happy%20Couple.md"
+            }
+        },
+        {
+            "fileName": "happy-couple-1221",
+            "displayName": "Happy Couple (1.2.2.1)"
+        },
+        {
+            "fileName": "hiveblood",
+            "displayName": "Hiveblood%",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Hiveblood%25.md"
+            }
+        },
+        {
+            "fileName": "lbc",
+            "displayName": "Lifeblood Core%"
+        },
+        {
+            "fileName": "low-te-dropless",
+            "displayName": "Low% True Ending Dropless",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Low%25%20True%20Ending%20Dropless.md"
+            }
+        },
+        {
+            "fileName": "marissa-audience",
+            "displayName": "Marissa Audience",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Marissa%20Audience.md"
+            }
+        },
+        {
+            "fileName": "marmu",
+            "displayName": "Marmu%"
+        },
+        {
+            "fileName": "max-0-geo",
+            "displayName": "Max% 0 Geo",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Max%25%200%20Geo.md"
+            }
+        },
+        {
+            "fileName": "mr-mushroom-ending",
+            "displayName": "Mr. Mushroom Ending",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Mr.%20Mushroom%20Ending.md"
+            }
+        },
+        {
+            "fileName": "myla",
+            "displayName": "Myla%",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Myla%25.md"
+            }
+        },
+        {
+            "fileName": "mylas-revenge",
+            "displayName": "Myla's Revenge",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Myla's%20Revenge.md"
+            }
+        },
+        {
+            "fileName": "nice",
+            "displayName": "Nice%",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Nice%25.md"
+            }
+        },
+        {
+            "fileName": "nice-1221",
+            "displayName": "Nice% (1.2.2.1)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Nice%25%20(1.2.2.1).md"
+            }
+        },
+        {
+            "fileName": "nkg",
+            "displayName": "NKG%",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/NKG%25.md"
+            }
+        },
+        {
+            "fileName": "nkg-nmms",
+            "displayName": "NKG% (No Main Menu Storage)",
+            "data": {}
+        },
+        {
+            "fileName": "nmg",
+            "displayName": "NMG%"
+        },
+        {
+            "fileName": "nosk",
+            "displayName": "Nosk%",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Nosk%25.md"
+            }
+        },
+        {
+            "fileName": "pop-percent",
+            "displayName": "Path of Pain%",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Path%20of%20Pain%25.md"
+            }
+        },
+        {
+            "fileName": "pure-snail",
+            "displayName": "Pure Snail",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Pure%20Snail.md"
+            }
+        },
+        {
+            "fileName": "p5bo",
+            "displayName": "Pantheon 5 Boss Order",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Pantheon%205%20Boss%20Order.md"
+            }
+        },
+        {
+            "fileName": "p5bo-breaks",
+            "displayName": "Pantheon 5 Boss Order (w/ breaks)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Pantheon%205%20Boss%20Order%20(w%EF%BC%8F%20breaks).md"
+            }
+        },
+        {
+            "fileName": "round",
+            "displayName": "Round%",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Round%25.md"
+            }
+        },
+        {
+            "fileName": "salubras-blessing",
+            "displayName": "Salubra's Blessing%",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Salubra's%20Blessing%25.md",
+                "searchTerms": [
+                    "Smooch"
+                ]
+            }
+        },
+        {
+            "fileName": "sbaco",
+            "displayName": "Salubra's Blessing% ACO",
+            "data": {
+                "searchTerms": [
+                    "Smooch",
+                    "Alphabetical Charm Order"
+                ]
+            }
+        },
+        {
+            "fileName": "sbcmo",
+            "displayName": "Salubra's Blessing% CMO",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Salubra's%20Blessing%25%20CMO.md",
+                "searchTerms": [
+                    "Smooch",
+                    "Charm Menu Order"
+                ]
+            }
+        },
+        {
+            "fileName": "sbico",
+            "displayName": "Salubra's Blessing% ICO",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Salubra's%20Blessing%25%20ICO.md",
+                "searchTerms": [
+                    "Smooch",
+                    "Intended Charm Order"
+                ]
+            }
+        },
+        {
+            "fileName": "save-myla",
+            "displayName": "Save Myla (Dash Slash route)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Save%20Myla%20(Dash%20Slash%20route).md"
+            }
+        },
+        {
+            "fileName": "shriek",
+            "displayName": "Shriek%",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Shriek%25.md"
+            }
+        },
+        {
+            "fileName": "stinky",
+            "displayName": "Stinky% Comfy",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Stinky%25%20Comfy.md"
+            }
+        },
+        {
+            "fileName": "spelless",
+            "displayName": "Spelless",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Spelless.md"
+            }
+        },
+        {
+            "fileName": "spelless-dreamshield",
+            "displayName": "Spelless (Dreamshield)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Spelless%20(Dreamshield).md"
+            }
+        },
+        {
+            "fileName": "spelless-low",
+            "displayName": "Low% Spelless"
+        },
+        {
+            "fileName": "spelless-te",
+            "displayName": "Spelless True Ending",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Spelless%20True%20Ending.md"
+            }
+        },
+        {
+            "fileName": "spelless-te-dreamshield",
+            "displayName": "Spelless True Ending (Dreamshield)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Spelless%20True%20Ending%20(Dreamshield).md"
+            }
+        },
+        {
+            "fileName": "spinach",
+            "displayName": "SPINACH%",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/SPINACH%25.md"
+            }
+        },
+        {
+            "fileName": "who-ag",
+            "displayName": "Who% (All Glitches)"
+        },
+        {
+            "fileName": "who-nmms-1028",
+            "displayName": "Who% (No Main Menu Storage, 1028)"
+        },
+        {
+            "fileName": "who-nmms-itemless",
+            "displayName": "Who% (No Main Menu Storage, itemless stagclip)"
+        },
+        {
+            "fileName": "who-cdash",
+            "displayName": "Who% (Crystal Heart)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Who%25%20(Crystal%20Heart).md"
+            }
+        },
+        {
+            "fileName": "who-wings",
+            "displayName": "Who% (Monarch Wings)",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Who%25%20(Monarch%20Wings).md"
+            }
+        },
+        {
+            "fileName": "witness",
+            "displayName": "Witness",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Witness.md",
+                "searchTerms": [
+                    "Quirrel"
+                ]
+            }
+        },
+        {
+            "fileName": "zote",
+            "displayName": "Zote%",
+            "data": {
+                "routeNotesURL": "https://github.com/hk-speedrunning/HK-Rules/blob/main/route-notes/Zote%25.md"
+            }
+        }
+    ]
 }


### PR DESCRIPTION
Pastebin is becoming super sketch with ads and stuff so all of the existing hksplitmaker routes have been added to the official HK rules/info repo.