### PR TITLE
Import pause_on_file_select from Xml

### DIFF
--- a/src/asset/silksong/categories/5-tools-ag.json
+++ b/src/asset/silksong/categories/5-tools-ag.json
@@ -12,5 +12,6 @@
     "gameName": "Hollow Knight: Silksong Category Extensions",
     "variables": {
         "5 Tools Subcategory": "All Glitches"
-    }
+    },
+    "pauseOnFileSelect": false
 }

--- a/src/asset/silksong/categories/act1-judgement-ag.json
+++ b/src/asset/silksong/categories/act1-judgement-ag.json
@@ -15,5 +15,6 @@
     "variables": {
         "Act 1 Route": "Judgement",
         "Act 1 Subcategory": "All Glitches"
-    }
+    },
+    "pauseOnFileSelect": false
 }

--- a/src/asset/silksong/categories/any-ag-swift-step.json
+++ b/src/asset/silksong/categories/any-ag-swift-step.json
@@ -15,5 +15,6 @@
     "variables": {
         "Any% Subcategory": "All Glitches",
         "Any% Drifters Cloak?": "Cloakless"
-    }
+    },
+    "pauseOnFileSelect": false
 }

--- a/src/asset/silksong/categories/any-ag.json
+++ b/src/asset/silksong/categories/any-ag.json
@@ -15,5 +15,6 @@
     "variables": {
         "Any% Subcategory": "All Glitches",
         "Any% Drifters Cloak?": "Cloakless"
-    }
+    },
+    "pauseOnFileSelect": false
 }

--- a/src/asset/silksong/categories/bath-ag.json
+++ b/src/asset/silksong/categories/bath-ag.json
@@ -10,5 +10,6 @@
     "gameName": "Hollow Knight: Silksong Category Extensions",
     "variables": {
         "Bath% Subcategory": "All Glitches"
-    }
+    },
+    "pauseOnFileSelect": false
 }

--- a/src/asset/silksong/categories/low-ag.json
+++ b/src/asset/silksong/categories/low-ag.json
@@ -14,5 +14,6 @@
     "gameName": "Hollow Knight: Silksong",
     "variables": {
         "Low% Subcategory": "All Glitches"
-    }
+    },
+    "pauseOnFileSelect": false
 }

--- a/src/asset/silksong/categories/twisted-ag.json
+++ b/src/asset/silksong/categories/twisted-ag.json
@@ -18,5 +18,6 @@
     "gameName": "Hollow Knight: Silksong Category Extensions",
     "variables": {
         "Twisted% Subcategory": "All Glitches"
-    }
+    },
+    "pauseOnFileSelect": false
 }

--- a/src/lib/lss.ts
+++ b/src/lib/lss.ts
@@ -33,6 +33,7 @@ interface ParsedHKAutoSplitterSettings {
 
 interface ParsedSSAutosplitterSettings {
   autosplitIds: Array<string>;
+  pauseOnFileSelect: boolean | undefined;
 }
 
 interface ParsedSplitId {
@@ -751,7 +752,19 @@ function parseSSAutoSplitterSettings(
     const autosplitId = settingsNode.getAttribute("value") ?? "ManualSplit";
     autosplitIds.push(autosplitId);
   }
-  return { autosplitIds };
+  const xmlDocPauseOnFileSelect = xmlDocCustomSettings.querySelector(
+    '[id="pause_on_file_select"]'
+  );
+  let pauseOnFileSelect: boolean | undefined = undefined;
+  if (xmlDocPauseOnFileSelect) {
+    const pauseOnFileSelectStr = getTextContent(xmlDocPauseOnFileSelect);
+    if (pauseOnFileSelectStr == "True") {
+      pauseOnFileSelect = true;
+    } else if (pauseOnFileSelectStr == "False") {
+      pauseOnFileSelect = false;
+    }
+  }
+  return { autosplitIds, pauseOnFileSelect };
 }
 
 function importHKSplitsXml(str: string): Config {
@@ -947,7 +960,8 @@ function importSSSplitsXml(str: string): Config {
       throw new Error(`Failed to import splits: missing AutoSplitterSettings`);
     }
   }
-  const { autosplitIds } = parseSSAutoSplitterSettings(autoSplitterSettings);
+  const { autosplitIds, pauseOnFileSelect } =
+    parseSSAutoSplitterSettings(autoSplitterSettings);
   // autosplitIds vs splitIds: autosplitIds do not contain "-" for subsplits, splitIds can
   const parsedSplitIds: ParsedSplitId[] = [];
   autosplitIds.forEach((autosplitId) => {
@@ -1028,6 +1042,7 @@ function importSSSplitsXml(str: string): Config {
     endingSplit: endName.length > 0 ? { name: endName } : undefined,
     gameName,
     variables: hasVariables ? potentialVariables : undefined,
+    pauseOnFileSelect,
   };
   if (offset && offset !== DEFAULT_OFFSET) {
     config = { offset, ...config };

--- a/src/lib/lss.ts
+++ b/src/lib/lss.ts
@@ -20,6 +20,7 @@ export interface Config {
   gameName: string;
   variables?: Record<string, string>;
   offset?: string;
+  pauseOnFileSelect?: boolean;
 }
 
 interface ParsedHKAutoSplitterSettings {
@@ -148,17 +149,36 @@ const SILKSONG_SCRIPT_NAME_NODE = {
 };
 
 // <Setting id="pause_on_file_select" type="bool">False</Setting>
-const SILKSONG_PAUSE_ON_FILE_SELECT_FALSE_NODE = {
-  Setting: [
-    {
-      _attr: {
-        id: "pause_on_file_select",
-        type: "bool",
+function silksongPauseOnFileSelectNodes(
+  pauseOnFileSelect: boolean | undefined,
+  variables: Record<string, string> | undefined
+): Array<xml.XmlObject> {
+  if (pauseOnFileSelect === undefined) {
+    const isAllGlitches =
+      variables && Object.values(variables).some((v) => v === "All Glitches");
+    if (isAllGlitches) {
+      pauseOnFileSelect = false;
+    }
+  }
+
+  if (pauseOnFileSelect === undefined) {
+    return [];
+  } else {
+    return [
+      {
+        Setting: [
+          {
+            _attr: {
+              id: "pause_on_file_select",
+              type: "bool",
+            },
+          },
+          pauseOnFileSelect ? "True" : "False",
+        ],
       },
-    },
-    "False",
-  ],
-};
+    ];
+  }
+}
 
 export async function createSplitsXml(
   config: Config,
@@ -313,18 +333,15 @@ export async function createSplitsXml(
       ];
       break;
     case "silksong": {
-      const isAllGlitches =
-        config.variables &&
-        Object.values(config.variables).some((v) => v === "All Glitches");
-      const pauseOnFileSelect = isAllGlitches
-        ? [SILKSONG_PAUSE_ON_FILE_SELECT_FALSE_NODE]
-        : [];
       autosplitterSettings = [
         { Version: "1.0" },
         {
           CustomSettings: [
             SILKSONG_SCRIPT_NAME_NODE,
-            ...pauseOnFileSelect,
+            ...silksongPauseOnFileSelectNodes(
+              config.pauseOnFileSelect,
+              config.variables
+            ),
             {
               Setting: [
                 { _attr: { id: "splits", type: "list" } },
@@ -365,11 +382,9 @@ export async function createSplitsXml(
 
 function makeAutoSplittingRuntimeComponent(
   splitIds: Array<string>,
-  isAllGlitches: boolean | undefined
+  pauseOnFileSelect: boolean | undefined,
+  variables: Record<string, string> | undefined
 ): Record<string, unknown> {
-  const pauseOnFileSelect = isAllGlitches
-    ? [SILKSONG_PAUSE_ON_FILE_SELECT_FALSE_NODE]
-    : [];
   const splitList = [
     {
       Setting: [
@@ -384,7 +399,7 @@ function makeAutoSplittingRuntimeComponent(
         _attr: { id: `splits_${i}_item`, type: "string", value: name },
       },
     })),
-    ...pauseOnFileSelect,
+    ...silksongPauseOnFileSelectNodes(pauseOnFileSelect, variables),
     {
       Setting: [{ _attr: { id: "hit_counter", type: "bool" } }, "True"],
     },
@@ -416,9 +431,6 @@ export function createLayoutXml(config: Config, game: Game): string {
   if (game !== "silksong") {
     throw new Error("layout generation only supported for silksong");
   }
-  const isAllGlitches =
-    config.variables &&
-    Object.values(config.variables).some((v) => v === "All Glitches");
   const layoutObj = [
     {
       Layout: [
@@ -480,7 +492,11 @@ export function createLayoutXml(config: Config, game: Game): string {
         },
         {
           Components: [
-            makeAutoSplittingRuntimeComponent(config.splitIds, isAllGlitches),
+            makeAutoSplittingRuntimeComponent(
+              config.splitIds,
+              config.pauseOnFileSelect,
+              config.variables
+            ),
             {
               Component: [
                 { Path: "LiveSplit.Title.dll" },

--- a/src/lib/lss.ts
+++ b/src/lib/lss.ts
@@ -175,7 +175,7 @@ function silksongPauseOnFileSelectNodes(
               type: "bool",
             },
           },
-          pauseOnFileSelect ? "True" : "False",
+          pauseOnFileSelectMut ? "True" : "False",
         ],
       },
     ];

--- a/src/lib/lss.ts
+++ b/src/lib/lss.ts
@@ -755,7 +755,7 @@ function parseSSAutoSplitterSettings(
   const xmlDocPauseOnFileSelect = xmlDocCustomSettings.querySelector(
     '[id="pause_on_file_select"]'
   );
-  let pauseOnFileSelect: boolean | undefined = undefined;
+  let pauseOnFileSelect: boolean | undefined;
   if (xmlDocPauseOnFileSelect) {
     const pauseOnFileSelectStr = getTextContent(xmlDocPauseOnFileSelect);
     if (pauseOnFileSelectStr == "True") {

--- a/src/lib/lss.ts
+++ b/src/lib/lss.ts
@@ -154,15 +154,16 @@ function silksongPauseOnFileSelectNodes(
   pauseOnFileSelect: boolean | undefined,
   variables: Record<string, string> | undefined
 ): Array<xml.XmlObject> {
-  if (pauseOnFileSelect === undefined) {
+  let pauseOnFileSelectMut = pauseOnFileSelect;
+  if (pauseOnFileSelectMut === undefined) {
     const isAllGlitches =
       variables && Object.values(variables).some((v) => v === "All Glitches");
     if (isAllGlitches) {
-      pauseOnFileSelect = false;
+      pauseOnFileSelectMut = false;
     }
   }
 
-  if (pauseOnFileSelect === undefined) {
+  if (pauseOnFileSelectMut === undefined) {
     return [];
   } else {
     return [

--- a/src/schema/silksong/splits.schema.json
+++ b/src/schema/silksong/splits.schema.json
@@ -33,6 +33,10 @@
             "description": "Additional Info",
             "type": "object"
         },
+        "pauseOnFileSelect": {
+            "description": "Pause GameTime on File Select (Required false for Glitched)",
+            "type": "boolean"
+        },
         "splitIds": {
             "type": "array",
             "items": {


### PR DESCRIPTION
> Oh, no, i just used hksm to modify my splits, and it reenabled pause on file select

> was the subcategory set to All Glitches? that's the only logic that disables it

> It was when I imported them

> I can look into importing that setting on its own

> importing that setting on its own sounds like a good idea anyway